### PR TITLE
fix: the change assistant didn't take effect immediately #45

### DIFF
--- a/src/components/ConnectionSidebar.tsx
+++ b/src/components/ConnectionSidebar.tsx
@@ -132,7 +132,7 @@ const ConnectionSidebar = () => {
   };
 
   const handleConversationSelect = (conversation: Conversation) => {
-    conversationStore.setCurrentConversation(conversation);
+    conversationStore.setCurrentConversation(conversation.id);
     if (layoutStore.isMobileView) {
       layoutStore.toggleSidebar(false);
     }
@@ -148,7 +148,7 @@ const ConnectionSidebar = () => {
 
   const handleDeleteConversation = (conversation: Conversation) => {
     conversationStore.clearConversation((item) => item.id !== conversation.id);
-    if (conversationStore.currentConversation?.id === conversation.id) {
+    if (conversationStore.currentConversationId === conversation.id) {
       conversationStore.setCurrentConversation(undefined);
     }
   };
@@ -244,11 +244,11 @@ const ConnectionSidebar = () => {
                 <div
                   key={conversation.id}
                   className={`w-full mt-2 first:mt-4 py-3 pl-4 pr-2 rounded-lg flex flex-row justify-start items-center cursor-pointer dark:text-gray-300 border border-transparent group hover:bg-white dark:hover:bg-zinc-800 ${
-                    conversation.id === conversationStore.currentConversation?.id && "bg-white dark:bg-zinc-800 border-gray-200 font-medium"
+                    conversation.id === conversationStore.currentConversationId && "bg-white dark:bg-zinc-800 border-gray-200 font-medium"
                   }`}
                   onClick={() => handleConversationSelect(conversation)}
                 >
-                  {conversation.id === conversationStore.currentConversation?.id ? (
+                  {conversation.id === conversationStore.currentConversationId ? (
                     <Icon.IoChatbubble className="w-5 h-auto mr-1.5 shrink-0" />
                   ) : (
                     <Icon.IoChatbubbleOutline className="w-5 h-auto mr-1.5 opacity-80 shrink-0" />

--- a/src/components/ConnectionSidebar.tsx
+++ b/src/components/ConnectionSidebar.tsx
@@ -132,7 +132,7 @@ const ConnectionSidebar = () => {
   };
 
   const handleConversationSelect = (conversation: Conversation) => {
-    conversationStore.setCurrentConversation(conversation.id);
+    conversationStore.setCurrentConversationId(conversation.id);
     if (layoutStore.isMobileView) {
       layoutStore.toggleSidebar(false);
     }
@@ -149,7 +149,7 @@ const ConnectionSidebar = () => {
   const handleDeleteConversation = (conversation: Conversation) => {
     conversationStore.clearConversation((item) => item.id !== conversation.id);
     if (conversationStore.currentConversationId === conversation.id) {
-      conversationStore.setCurrentConversation(undefined);
+      conversationStore.setCurrentConversationId(undefined);
     }
   };
 

--- a/src/components/ConversationView/Header.tsx
+++ b/src/components/ConversationView/Header.tsx
@@ -13,8 +13,8 @@ const Header = (props: Props) => {
   const layoutStore = useLayoutStore();
   const conversationStore = useConversationStore();
   const isDarkMode = useDarkMode();
-  const currentConversation = conversationStore.currentConversation;
-  const title = currentConversation?.title || "SQL Chat";
+  const currentConversationId = conversationStore.currentConversationId;
+  const title = conversationStore.getConversationById(currentConversationId)?.title || "SQL Chat";
 
   useEffect(() => {
     document.title = `${title}`;

--- a/src/components/ConversationView/MessageTextarea.tsx
+++ b/src/components/ConversationView/MessageTextarea.tsx
@@ -34,7 +34,7 @@ const MessageTextarea = (props: Props) => {
   };
 
   const handleSend = async () => {
-    let conversation = conversationStore.currentConversation;
+    let conversation = conversationStore.getConversationById(conversationStore.currentConversationId);
     if (!conversation) {
       const currentConnectionCtx = connectionStore.currentConnectionCtx;
       if (!currentConnectionCtx) {

--- a/src/components/ConversationView/index.tsx
+++ b/src/components/ConversationView/index.tsx
@@ -99,7 +99,7 @@ const ConversationView = () => {
         conversation.connectionId === connectionStore.currentConnectionCtx?.connection.id &&
         conversation.databaseName === connectionStore.currentConnectionCtx?.database?.name
     );
-    conversationStore.setCurrentConversation(head(conversationList)?.id);
+    conversationStore.setCurrentConversationId(head(conversationList)?.id);
   }, [currentConversation, connectionStore.currentConnectionCtx]);
 
   const sendMessageToCurrentConversation = async () => {

--- a/src/components/ConversationView/index.tsx
+++ b/src/components/ConversationView/index.tsx
@@ -32,7 +32,7 @@ const ConversationView = () => {
   const [isStickyAtBottom, setIsStickyAtBottom] = useState<boolean>(true);
   const [showHeaderShadow, setShowHeaderShadow] = useState<boolean>(false);
   const conversationViewRef = useRef<HTMLDivElement>(null);
-  const currentConversation = conversationStore.currentConversation;
+  const currentConversation = conversationStore.getConversationById(conversationStore.currentConversationId);
   const messageList = messageStore.messageList.filter((message) => message.conversationId === currentConversation?.id);
   const lastMessage = last(messageList);
 
@@ -99,11 +99,10 @@ const ConversationView = () => {
         conversation.connectionId === connectionStore.currentConnectionCtx?.connection.id &&
         conversation.databaseName === connectionStore.currentConnectionCtx?.database?.name
     );
-    conversationStore.setCurrentConversation(head(conversationList));
+    conversationStore.setCurrentConversation(head(conversationList)?.id);
   }, [currentConversation, connectionStore.currentConnectionCtx]);
 
   const sendMessageToCurrentConversation = async () => {
-    const currentConversation = conversationStore.getState().currentConversation;
     if (!currentConversation) {
       return;
     }

--- a/src/components/EmptyView.tsx
+++ b/src/components/EmptyView.tsx
@@ -21,7 +21,7 @@ const EmptyView = (props: Props) => {
   const isDarkMode = useDarkMode();
 
   const handleExampleClick = async (content: string) => {
-    let conversation = conversationStore.currentConversation;
+    let conversation = conversationStore.getConversationById(conversationStore.currentConversationId);
     if (!conversation) {
       const currentConnectionCtx = connectionStore.currentConnectionCtx;
       if (!currentConnectionCtx) {

--- a/src/store/conversation.ts
+++ b/src/store/conversation.ts
@@ -19,7 +19,7 @@ interface ConversationState {
   conversationList: Conversation[];
   currentConversationId?: Id;
   createConversation: (connectionId?: Id, databaseName?: string) => Conversation;
-  setCurrentConversation: (Conversation: Id | undefined) => void;
+  setCurrentConversation: (conversationId: Id | undefined) => void;
   getConversationById: (conversationId: Id | undefined) => Conversation | undefined;
   updateConversation: (conversationId: Id, conversation: Partial<Conversation>) => void;
   clearConversation: (filter: (conversation: Conversation) => boolean) => void;

--- a/src/store/conversation.ts
+++ b/src/store/conversation.ts
@@ -17,10 +17,10 @@ const getDefaultConversation = (): Conversation => {
 interface ConversationState {
   getState: () => ConversationState;
   conversationList: Conversation[];
-  currentConversation?: Conversation;
+  currentConversationId?: Id;
   createConversation: (connectionId?: Id, databaseName?: string) => Conversation;
-  setCurrentConversation: (Conversation: Conversation | undefined) => void;
-  getConversationById: (conversationId: Id) => Conversation | undefined;
+  setCurrentConversation: (Conversation: Id | undefined) => void;
+  getConversationById: (conversationId: Id | undefined) => Conversation | undefined;
   updateConversation: (conversationId: Id, conversation: Partial<Conversation>) => void;
   clearConversation: (filter: (conversation: Conversation) => boolean) => void;
 }
@@ -45,8 +45,8 @@ export const useConversationStore = create<ConversationState>()(
         }));
         return conversation;
       },
-      setCurrentConversation: (conversation: Conversation | undefined) => set(() => ({ currentConversation: conversation })),
-      getConversationById: (conversationId: Id) => {
+      setCurrentConversation: (conversation: Id | undefined) => set(() => ({ currentConversationId: conversation })),
+      getConversationById: (conversationId: Id | undefined) => {
         return get().conversationList.find((item) => item.id === conversationId);
       },
       updateConversation: (conversationId: Id, conversation: Partial<Conversation>) => {
@@ -75,7 +75,7 @@ export const useConversationStore = create<ConversationState>()(
               conversation.assistantId = "sql-chat-bot";
             }
           }
-          state.currentConversation = undefined;
+          state.currentConversationId = undefined;
         }
 
         return state;

--- a/src/store/conversation.ts
+++ b/src/store/conversation.ts
@@ -19,7 +19,7 @@ interface ConversationState {
   conversationList: Conversation[];
   currentConversationId?: Id;
   createConversation: (connectionId?: Id, databaseName?: string) => Conversation;
-  setCurrentConversation: (conversationId: Id | undefined) => void;
+  setCurrentConversationId: (conversationId: Id | undefined) => void;
   getConversationById: (conversationId: Id | undefined) => Conversation | undefined;
   updateConversation: (conversationId: Id, conversation: Partial<Conversation>) => void;
   clearConversation: (filter: (conversation: Conversation) => boolean) => void;
@@ -45,7 +45,7 @@ export const useConversationStore = create<ConversationState>()(
         }));
         return conversation;
       },
-      setCurrentConversation: (conversation: Id | undefined) => set(() => ({ currentConversationId: conversation })),
+      setCurrentConversationId: (conversation: Id | undefined) => set(() => ({ currentConversationId: conversation })),
       getConversationById: (conversationId: Id | undefined) => {
         return get().conversationList.find((item) => item.id === conversationId);
       },


### PR DESCRIPTION
Bug reason: 
when we change assistant, the `updateConversation` is called. the `conversationList` of State be updated. But `currentConversation` didn't be updated.

Solution options:
- update `currentConversation` at the same time of `updateConversation`
- change `currentConversation` to Conversation id 
- change `currentConversation` to Conversation index in Conversation array

🤔 After discussing with stevelgtm, I finally decided on option 2. I think it is an elegant and good design. 