### PR TITLE
chore: change the init value of table list in useConnectionStore

### DIFF
--- a/src/store/connection.ts
+++ b/src/store/connection.ts
@@ -72,7 +72,7 @@ export const useConnectionStore = create<ConnectionState>()(
             ({
               connectionId: connection.id,
               name: dbName,
-              tableList: {},
+              tableList: [],
             } as Database)
         );
         const databaseList = uniqBy(


### PR DESCRIPTION
In `database.ts`, we can see the type of tableList is Array.
```typscript
export interface Database {
  connectionId: Id;
  name: string;
  tableList: Table[];
}
```
But in the function `getOrFetchDatabaseList` of `connection.ts`.
```typescript        
const fetchedDatabaseList = data.map(
          (dbName) =>
            ({
              connectionId: connection.id,
              name: dbName,
              tableList: {},
            } as Database)
        );

```
`tableList` be set to `{}`. I think it is a wrong value. So I change to `[]`. 🤔