### PR TITLE
feat: optimize fetch database schema

### DIFF
--- a/src/lib/connectors/index.ts
+++ b/src/lib/connectors/index.ts
@@ -8,7 +8,7 @@ export interface Connector {
   execute: (databaseName: string, statement: string) => Promise<ExecutionResult>;
   getDatabases: () => Promise<string[]>;
   getTables: (databaseName: string) => Promise<string[]>;
-  getTableStructure: (databaseName: string, tableName: string) => Promise<string>;
+  getTableStructure: (databaseName: string, tableName: string, structureFetched: (tableName: string,structure: string)=> void) => Promise<string>;
 }
 
 export const newConnector = (connection: Connection): Connector => {

--- a/src/lib/connectors/index.ts
+++ b/src/lib/connectors/index.ts
@@ -8,7 +8,7 @@ export interface Connector {
   execute: (databaseName: string, statement: string) => Promise<ExecutionResult>;
   getDatabases: () => Promise<string[]>;
   getTables: (databaseName: string) => Promise<string[]>;
-  getTableStructure: (databaseName: string, tableName: string, structureFetched: (tableName: string,structure: string)=> void) => Promise<void>;
+  getTableStructure: (databaseName: string, tableName: string, structureFetched: (tableName: string, structure: string) => void) => Promise<void>;
 }
 
 export const newConnector = (connection: Connection): Connector => {

--- a/src/lib/connectors/index.ts
+++ b/src/lib/connectors/index.ts
@@ -8,7 +8,7 @@ export interface Connector {
   execute: (databaseName: string, statement: string) => Promise<ExecutionResult>;
   getDatabases: () => Promise<string[]>;
   getTables: (databaseName: string) => Promise<string[]>;
-  getTableStructure: (databaseName: string, tableName: string, structureFetched: (tableName: string,structure: string)=> void) => Promise<string>;
+  getTableStructure: (databaseName: string, tableName: string, structureFetched: (tableName: string,structure: string)=> void) => Promise<void>;
 }
 
 export const newConnector = (connection: Connection): Connector => {

--- a/src/lib/connectors/mssql/index.ts
+++ b/src/lib/connectors/mssql/index.ts
@@ -75,7 +75,7 @@ const getTables = async (connection: Connection, databaseName: string): Promise<
   return tableList;
 };
 
-const getTableStructure = async (connection: Connection, databaseName: string, tableName: string): Promise<string> => {
+const getTableStructure = async (connection: Connection, databaseName: string, tableName: string,  structureFetched: (tableName: string,structure: string)=> void): Promise<string> => {
   const pool = await getMSSQLConnection(connection);
   const request = pool.request();
   const { recordset } = await request.query(
@@ -89,7 +89,9 @@ const getTableStructure = async (connection: Connection, databaseName: string, t
       `${row["COLUMN_NAME"]} ${row["DATA_TYPE"].toUpperCase()} ${String(row["IS_NULLABLE"]).toUpperCase() === "NO" ? "NOT NULL" : ""}`
     );
   }
-
+  structureFetched(tableName, `CREATE TABLE [${tableName}] (
+    ${columnList.join(",\n")}
+  );`)
   return `CREATE TABLE [${tableName}] (
     ${columnList.join(",\n")}
   );`;
@@ -101,7 +103,7 @@ const newConnector = (connection: Connection): Connector => {
     execute: (databaseName: string, statement: string) => execute(connection, databaseName, statement),
     getDatabases: () => getDatabases(connection),
     getTables: (databaseName: string) => getTables(connection, databaseName),
-    getTableStructure: (databaseName: string, tableName: string) => getTableStructure(connection, databaseName, tableName),
+    getTableStructure: (databaseName: string, tableName: string,  structureFetched: (tableName: string,structure: string)=> void) => getTableStructure(connection, databaseName, tableName, structureFetched),
   };
 };
 

--- a/src/lib/connectors/mssql/index.ts
+++ b/src/lib/connectors/mssql/index.ts
@@ -75,7 +75,7 @@ const getTables = async (connection: Connection, databaseName: string): Promise<
   return tableList;
 };
 
-const getTableStructure = async (connection: Connection, databaseName: string, tableName: string,  structureFetched: (tableName: string,structure: string)=> void): Promise<void> => {
+const getTableStructure = async (connection: Connection, databaseName: string, tableName: string,  structureFetched: (tableName: string,structure: string) => void): Promise<void> => {
   const pool = await getMSSQLConnection(connection);
   const request = pool.request();
   const { recordset } = await request.query(
@@ -100,7 +100,7 @@ const newConnector = (connection: Connection): Connector => {
     execute: (databaseName: string, statement: string) => execute(connection, databaseName, statement),
     getDatabases: () => getDatabases(connection),
     getTables: (databaseName: string) => getTables(connection, databaseName),
-    getTableStructure: (databaseName: string, tableName: string,  structureFetched: (tableName: string,structure: string)=> void) => getTableStructure(connection, databaseName, tableName, structureFetched),
+    getTableStructure: (databaseName: string, tableName: string,  structureFetched: (tableName: string, structure: string) => void) => getTableStructure(connection, databaseName, tableName, structureFetched),
   };
 };
 

--- a/src/lib/connectors/mssql/index.ts
+++ b/src/lib/connectors/mssql/index.ts
@@ -75,7 +75,7 @@ const getTables = async (connection: Connection, databaseName: string): Promise<
   return tableList;
 };
 
-const getTableStructure = async (connection: Connection, databaseName: string, tableName: string,  structureFetched: (tableName: string,structure: string)=> void): Promise<string> => {
+const getTableStructure = async (connection: Connection, databaseName: string, tableName: string,  structureFetched: (tableName: string,structure: string)=> void): Promise<void> => {
   const pool = await getMSSQLConnection(connection);
   const request = pool.request();
   const { recordset } = await request.query(
@@ -91,10 +91,7 @@ const getTableStructure = async (connection: Connection, databaseName: string, t
   }
   structureFetched(tableName, `CREATE TABLE [${tableName}] (
     ${columnList.join(",\n")}
-  );`)
-  return `CREATE TABLE [${tableName}] (
-    ${columnList.join(",\n")}
-  );`;
+  );`);
 };
 
 const newConnector = (connection: Connection): Connector => {

--- a/src/lib/connectors/mysql/index.ts
+++ b/src/lib/connectors/mysql/index.ts
@@ -80,15 +80,14 @@ const getTables = async (connection: Connection, databaseName: string): Promise<
   return tableList;
 };
 
-const getTableStructure = async (connection: Connection, databaseName: string, tableName: string, structureFetched: (tableName: string,structure: string)=> void): Promise<string> => {
+const getTableStructure = async (connection: Connection, databaseName: string, tableName: string, structureFetched: (tableName: string,structure: string)=> void): Promise<void> => {
   const conn = await getMySQLConnection(connection);
   const [rows] = await conn.query<RowDataPacket[]>(`SHOW CREATE TABLE \`${databaseName}\`.\`${tableName}\`;`);
   conn.destroy();
   if (rows.length !== 1) {
     throw new Error("Unexpected number of rows.");
   }
-  structureFetched(tableName, rows[0]["Create Table"] || "")
-  return rows[0]["Create Table"] || "";
+  structureFetched(tableName, rows[0]["Create Table"] || "");
 };
 
 const newConnector = (connection: Connection): Connector => {

--- a/src/lib/connectors/mysql/index.ts
+++ b/src/lib/connectors/mysql/index.ts
@@ -80,13 +80,14 @@ const getTables = async (connection: Connection, databaseName: string): Promise<
   return tableList;
 };
 
-const getTableStructure = async (connection: Connection, databaseName: string, tableName: string): Promise<string> => {
+const getTableStructure = async (connection: Connection, databaseName: string, tableName: string, structureFetched: (tableName: string,structure: string)=> void): Promise<string> => {
   const conn = await getMySQLConnection(connection);
   const [rows] = await conn.query<RowDataPacket[]>(`SHOW CREATE TABLE \`${databaseName}\`.\`${tableName}\`;`);
   conn.destroy();
   if (rows.length !== 1) {
     throw new Error("Unexpected number of rows.");
   }
+  structureFetched(tableName, rows[0]["Create Table"] || "")
   return rows[0]["Create Table"] || "";
 };
 
@@ -96,7 +97,7 @@ const newConnector = (connection: Connection): Connector => {
     execute: (databaseName: string, statement: string) => execute(connection, databaseName, statement),
     getDatabases: () => getDatabases(connection),
     getTables: (databaseName: string) => getTables(connection, databaseName),
-    getTableStructure: (databaseName: string, tableName: string) => getTableStructure(connection, databaseName, tableName),
+    getTableStructure: (databaseName: string, tableName: string, structureFetched: (tableName: string,structure: string)=> void) => getTableStructure(connection, databaseName, tableName, structureFetched),
   };
 };
 

--- a/src/lib/connectors/mysql/index.ts
+++ b/src/lib/connectors/mysql/index.ts
@@ -80,7 +80,7 @@ const getTables = async (connection: Connection, databaseName: string): Promise<
   return tableList;
 };
 
-const getTableStructure = async (connection: Connection, databaseName: string, tableName: string, structureFetched: (tableName: string,structure: string)=> void): Promise<void> => {
+const getTableStructure = async (connection: Connection, databaseName: string, tableName: string, structureFetched: (tableName: string,structure: string) => void): Promise<void> => {
   const conn = await getMySQLConnection(connection);
   const [rows] = await conn.query<RowDataPacket[]>(`SHOW CREATE TABLE \`${databaseName}\`.\`${tableName}\`;`);
   conn.destroy();
@@ -96,7 +96,7 @@ const newConnector = (connection: Connection): Connector => {
     execute: (databaseName: string, statement: string) => execute(connection, databaseName, statement),
     getDatabases: () => getDatabases(connection),
     getTables: (databaseName: string) => getTables(connection, databaseName),
-    getTableStructure: (databaseName: string, tableName: string, structureFetched: (tableName: string,structure: string)=> void) => getTableStructure(connection, databaseName, tableName, structureFetched),
+    getTableStructure: (databaseName: string, tableName: string, structureFetched: (tableName: string, structure: string) => void) => getTableStructure(connection, databaseName, tableName, structureFetched),
   };
 };
 

--- a/src/lib/connectors/postgres/index.ts
+++ b/src/lib/connectors/postgres/index.ts
@@ -83,7 +83,7 @@ const getTables = async (connection: Connection, databaseName: string): Promise<
   return tableList;
 };
 
-const getTableStructure = async (connection: Connection, databaseName: string, tableName: string,  structureFetched: (tableName: string,structure: string)=> void): Promise<void> => {
+const getTableStructure = async (connection: Connection, databaseName: string, tableName: string,  structureFetched: (tableName: string,structure: string) => void): Promise<void> => {
   connection.database = databaseName;
   const client = newPostgresClient(connection);
   await client.connect();
@@ -110,7 +110,7 @@ const newConnector = (connection: Connection): Connector => {
     execute: (databaseName: string, statement: string) => execute(connection, databaseName, statement),
     getDatabases: () => getDatabases(connection),
     getTables: (databaseName: string) => getTables(connection, databaseName),
-    getTableStructure: (databaseName: string, tableName: string, structureFetched: (tableName: string,structure: string)=> void) => getTableStructure(connection, databaseName, tableName, structureFetched),
+    getTableStructure: (databaseName: string, tableName: string, structureFetched: (tableName: string, structure: string) => void) => getTableStructure(connection, databaseName, tableName, structureFetched),
   };
 };
 

--- a/src/lib/connectors/postgres/index.ts
+++ b/src/lib/connectors/postgres/index.ts
@@ -83,7 +83,7 @@ const getTables = async (connection: Connection, databaseName: string): Promise<
   return tableList;
 };
 
-const getTableStructure = async (connection: Connection, databaseName: string, tableName: string): Promise<string> => {
+const getTableStructure = async (connection: Connection, databaseName: string, tableName: string,  structureFetched: (tableName: string,structure: string)=> void): Promise<string> => {
   connection.database = databaseName;
   const client = newPostgresClient(connection);
   await client.connect();
@@ -99,6 +99,9 @@ const getTableStructure = async (connection: Connection, databaseName: string, t
       `${row["column_name"]} ${row["data_type"].toUpperCase()} ${String(row["is_nullable"]).toUpperCase() === "NO" ? "NOT NULL" : ""}`
     );
   }
+  structureFetched(tableName, `CREATE TABLE \`${tableName}\` (
+    ${columnList.join(",\n")}
+  );`);
   return `CREATE TABLE \`${tableName}\` (
     ${columnList.join(",\n")}
   );`;
@@ -110,7 +113,7 @@ const newConnector = (connection: Connection): Connector => {
     execute: (databaseName: string, statement: string) => execute(connection, databaseName, statement),
     getDatabases: () => getDatabases(connection),
     getTables: (databaseName: string) => getTables(connection, databaseName),
-    getTableStructure: (databaseName: string, tableName: string) => getTableStructure(connection, databaseName, tableName),
+    getTableStructure: (databaseName: string, tableName: string, structureFetched: (tableName: string,structure: string)=> void) => getTableStructure(connection, databaseName, tableName, structureFetched),
   };
 };
 

--- a/src/lib/connectors/postgres/index.ts
+++ b/src/lib/connectors/postgres/index.ts
@@ -83,7 +83,7 @@ const getTables = async (connection: Connection, databaseName: string): Promise<
   return tableList;
 };
 
-const getTableStructure = async (connection: Connection, databaseName: string, tableName: string,  structureFetched: (tableName: string,structure: string)=> void): Promise<string> => {
+const getTableStructure = async (connection: Connection, databaseName: string, tableName: string,  structureFetched: (tableName: string,structure: string)=> void): Promise<void> => {
   connection.database = databaseName;
   const client = newPostgresClient(connection);
   await client.connect();
@@ -102,9 +102,6 @@ const getTableStructure = async (connection: Connection, databaseName: string, t
   structureFetched(tableName, `CREATE TABLE \`${tableName}\` (
     ${columnList.join(",\n")}
   );`);
-  return `CREATE TABLE \`${tableName}\` (
-    ${columnList.join(",\n")}
-  );`;
 };
 
 const newConnector = (connection: Connection): Connector => {

--- a/src/pages/api/connection/db_schema.ts
+++ b/src/pages/api/connection/db_schema.ts
@@ -25,7 +25,6 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
     Promise.all(rawTableNameList.map(async (tableName) => 
       connector.getTableStructure(db,tableName,structureFetched)
     )).then(() => {
-      console.log( tableStructures)
       res.status(200).json({
         data: tableStructures,
       });  

--- a/src/pages/api/connection/db_schema.ts
+++ b/src/pages/api/connection/db_schema.ts
@@ -16,14 +16,14 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
     const connector = newConnector(connection);
     const tableStructures: Table[] = [];
     const rawTableNameList = await connector.getTables(db);
-    const structureFetched = (tableName:string , structure:string) => {
+    const structureFetched = (tableName:string, structure:string) => {
       tableStructures.push({
         name: tableName,
         structure,
       });
     }
     Promise.all(rawTableNameList.map(async (tableName) => 
-      connector.getTableStructure(db,tableName,structureFetched)
+      connector.getTableStructure(db, tableName, structureFetched)
     )).then(() => {
       res.status(200).json({
         data: tableStructures,

--- a/src/pages/api/connection/db_schema.ts
+++ b/src/pages/api/connection/db_schema.ts
@@ -16,8 +16,14 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
     const connector = newConnector(connection);
     const tableStructures: Table[] = [];
     const rawTableNameList = await connector.getTables(db);
+    const structureFetched = (tableName:string , structure:string) => {
+      tableStructures.push({
+        name: tableName,
+        structure,
+      });
+    }
     for (const tableName of rawTableNameList) {
-      const structure = await connector.getTableStructure(db, tableName);
+      const structure = await connector.getTableStructure(db, tableName, structureFetched);
       tableStructures.push({
         name: tableName,
         structure,

--- a/src/pages/api/connection/db_schema.ts
+++ b/src/pages/api/connection/db_schema.ts
@@ -22,15 +22,13 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
         structure,
       });
     }
-    for (const tableName of rawTableNameList) {
-      const structure = await connector.getTableStructure(db, tableName, structureFetched);
-      tableStructures.push({
-        name: tableName,
-        structure,
-      });
-    }
-    res.status(200).json({
-      data: tableStructures,
+    Promise.all(rawTableNameList.map(async (tableName) => 
+      connector.getTableStructure(db,tableName,structureFetched)
+    )).then(() => {
+      console.log( tableStructures)
+      res.status(200).json({
+        data: tableStructures,
+      });  
     });
   } catch (error: any) {
     res.status(400).json({


### PR DESCRIPTION
## What does the PR do?
resolve https://github.com/sqlchat/sqlchat/issues/64
- refactor db_schema to async
- use callback in `getTableStructure` instead of return

## Speed test:

### Test 1
the database contains 189 tables. `api/connection/db_schema`
- sync to fetch(old):
<img width="620" alt="CleanShot 2023-04-24 at 20 12 24@2x" src="https://user-images.githubusercontent.com/29306285/233992638-a8c63fd3-c153-442f-9af3-7861361954b1.png">

- async to fetch(new):
<img width="618" alt="CleanShot 2023-04-24 at 20 07 19@2x" src="https://user-images.githubusercontent.com/29306285/233991483-8d500508-c5e0-49d3-9568-bc31173f317a.png">

2 min => 8 s

### Test2
the database contains 4 tables. `api/connection/db_schema`
- sync to fetch(old):
<img width="620" alt="CleanShot 2023-04-24 at 20 13 22@2x" src="https://user-images.githubusercontent.com/29306285/233992919-86cdd0d0-663d-4b74-a325-76b5bfdfbd16.png">

- async to fetch(new):
<img width="620" alt="CleanShot 2023-04-24 at 20 14 31@2x" src="https://user-images.githubusercontent.com/29306285/233993086-c2c252f5-b699-44f7-9941-e879c3b36a6d.png">

1.45 s => 811 ms