### PR TITLE
chore: delete unused import

### DIFF
--- a/src/components/ConversationView/index.tsx
+++ b/src/components/ConversationView/index.tsx
@@ -1,5 +1,5 @@
 import axios from "axios";
-import { first, head, last } from "lodash-es";
+import { head, last } from "lodash-es";
 import { useEffect, useRef, useState } from "react";
 import { toast } from "react-hot-toast";
 import { API_KEY } from "@/env";


### PR DESCRIPTION
In the [commit](https://github.com/sqlchat/sqlchat/commit/69fd60ce76ca73f35b73958242c22d528b95b0f3). the `first` function was deleted, but the import didn't change. 

<img width="530" alt="CleanShot 2023-05-05 at 23 00 43@2x" src="https://user-images.githubusercontent.com/29306285/236494839-9e632712-bd82-4186-9c0e-c4dccdaeed7c.png">
