### PR TITLE
fix: some multiple select style problem

### DIFF
--- a/src/components/kit/MultipleSelect.tsx
+++ b/src/components/kit/MultipleSelect.tsx
@@ -45,13 +45,13 @@ const MultipleSelect = (props: Props & { children?: ReactNode }) => {
 
           {itemList.map((item) => (
             <Listbox.Option
-              className="w-full px-3 py-2 whitespace-nowrap truncate text-ellipsis overflow-x-hidden text-sm rounded-lg flex flex-row justify-between items-center cursor-pointer hover:bg-gray-100 dark:hover:bg-zinc-800"
+              className="w-full px-3 py-2 whitespace-nowrap truncate text-ellipsis overflow-x-hidden text-sm rounded-lg flex flex-row justify-between items-center cursor-pointer dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-zinc-800"
               key={item.value}
               value={item.value}
             >
-              <div className="dark:text-gray-300 truncate">{item.label}</div>
+              <div className="truncate">{item.label}</div>
               {(value.find((v: string) => v === item.value) ? true : false) ? (
-                <span className="w-5 h-auto dark:text-gray-300">
+                <span className="w-5 h-auto">
                   <Icon.BiCheck className="w-full h-auto" aria-hidden="true" />
                 </span>
               ) : null}

--- a/src/components/kit/MultipleSelect.tsx
+++ b/src/components/kit/MultipleSelect.tsx
@@ -1,6 +1,5 @@
 import { Listbox, Transition } from "@headlessui/react";
 import { Fragment, ReactNode, useState } from "react";
-import { CheckIcon } from "@heroicons/react/20/solid";
 import * as SelectUI from "@radix-ui/react-select";
 import Icon from "../Icon";
 
@@ -37,9 +36,9 @@ const MultipleSelect = (props: Props & { children?: ReactNode }) => {
         leaveFrom="opacity-100"
         leaveTo="opacity-0"
       >
-        <Listbox.Options className="absolute p-1 mt-1 max-h-60 overflow-y-auto scrollbar-hide w-full overflow-auto rounded-md bg-white py-1 text-base shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none sm:text-sm">
+        <Listbox.Options className="absolute border rounded-lg drop-shadow-lg dark:border-zinc-800 p-1 mt-1 max-h-80 overflow-y-auto scrollbar-hide w-full overflow-auto bg-white dark:bg-zinc-700 py-1 text-base shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none sm:text-sm">
           {children && (
-            <Listbox.Option key="button" value="button">
+            <Listbox.Option className="px-2 py-2" key="button" value="button">
               {children}
             </Listbox.Option>
           )}
@@ -50,10 +49,10 @@ const MultipleSelect = (props: Props & { children?: ReactNode }) => {
               key={item.value}
               value={item.value}
             >
-              {item.label}
+              <div className="dark:text-gray-300 truncate">{item.label}</div>
               {(value.find((v: string) => v === item.value) ? true : false) ? (
-                <span className=" inset-y-0 left-0 flex items-center pl-3 text-black">
-                  <CheckIcon className="h-5 w-5" aria-hidden="true" />
+                <span className="w-5 h-auto dark:text-gray-300">
+                  <Icon.BiCheck className="w-full h-auto" aria-hidden="true" />
                 </span>
               ) : null}
             </Listbox.Option>


### PR DESCRIPTION
I forget some specific cases in the previous [PR](https://github.com/sqlchat/sqlchat/pull/82), especially dark mode🥲 So the style of multiple select has some inconsistencies.

## What does the PR do?
- Unified the icon and color with `Select`.
- Add the color schemes for dark mode.
- Unified the style with `Select`, such as border and shadow.


light:
![CleanShot 2023-05-14 at 12 20 13](https://github.com/sqlchat/sqlchat/assets/29306285/b9145309-c7de-4c89-9d01-de2a2425655f)


dark:
![CleanShot 2023-05-14 at 12 19 47](https://github.com/sqlchat/sqlchat/assets/29306285/48f75ee1-b8ce-4e8e-9ae2-572422e274b9)
