### PR TITLE
feat: update SQL in message when SQL of QueryDrawer changes

### DIFF
--- a/src/components/CodeBlock.tsx
+++ b/src/components/CodeBlock.tsx
@@ -6,14 +6,16 @@ import { oneDark } from "react-syntax-highlighter/dist/cjs/styles/prism";
 import { useConnectionStore, useQueryStore } from "@/store";
 import Icon from "./Icon";
 import Tooltip from "./kit/Tooltip";
+import { Id } from "@/types";
 
 interface Props {
   language: string;
   value: string;
+  messageId: Id;
 }
 
 export const CodeBlock = (props: Props) => {
-  const { language, value } = props;
+  const { language, value, messageId } = props;
   const { t } = useTranslation();
   const connectionStore = useConnectionStore();
   const queryStore = useQueryStore();
@@ -37,6 +39,7 @@ export const CodeBlock = (props: Props) => {
     queryStore.setContext({
       connection: currentConnectionCtx.connection,
       database: currentConnectionCtx.database,
+      messageId: messageId,
       statement: value,
     });
     queryStore.toggleDrawer(true);

--- a/src/components/ConnectionSidebar.tsx
+++ b/src/components/ConnectionSidebar.tsx
@@ -29,7 +29,13 @@ const ConnectionSidebar = () => {
   const selectedTablesName: string[] =
     conversationStore.getConversationById(conversationStore.currentConversationId)?.selectedTablesName || [];
   const tableSchemaLoadingState = useLoading();
+<<<<<<< HEAD
   const currentConversation = conversationStore.getConversationById(conversationStore.currentConversationId);
+=======
+  const currentConversation = conversationStore.getConversationById(
+    conversationStore.currentConversationId
+  );
+>>>>>>> origin/fix/cannot_select_table
 
   useEffect(() => {
     const handleWindowResize = () => {
@@ -119,7 +125,13 @@ const ConnectionSidebar = () => {
 
   const handleAllSelect = async () => {
     createConversation();
+<<<<<<< HEAD
     conversationStore.updateSelectedTablesName(tableList.map((table) => table.name));
+=======
+    conversationStore.updateSelectedTablesName(
+      tableList.map((table) => table.name)
+    );
+>>>>>>> origin/fix/cannot_select_table
   };
 
   const handleEmptySelect = async () => {

--- a/src/components/ConnectionSidebar.tsx
+++ b/src/components/ConnectionSidebar.tsx
@@ -29,13 +29,7 @@ const ConnectionSidebar = () => {
   const selectedTablesName: string[] =
     conversationStore.getConversationById(conversationStore.currentConversationId)?.selectedTablesName || [];
   const tableSchemaLoadingState = useLoading();
-<<<<<<< HEAD
   const currentConversation = conversationStore.getConversationById(conversationStore.currentConversationId);
-=======
-  const currentConversation = conversationStore.getConversationById(
-    conversationStore.currentConversationId
-  );
->>>>>>> origin/fix/cannot_select_table
 
   useEffect(() => {
     const handleWindowResize = () => {
@@ -125,13 +119,7 @@ const ConnectionSidebar = () => {
 
   const handleAllSelect = async () => {
     createConversation();
-<<<<<<< HEAD
     conversationStore.updateSelectedTablesName(tableList.map((table) => table.name));
-=======
-    conversationStore.updateSelectedTablesName(
-      tableList.map((table) => table.name)
-    );
->>>>>>> origin/fix/cannot_select_table
   };
 
   const handleEmptySelect = async () => {

--- a/src/components/ConversationView/MessageView.tsx
+++ b/src/components/ConversationView/MessageView.tsx
@@ -125,6 +125,7 @@ const MessageView = (props: Props) => {
                         <pre className={`${className || ""} w-full p-0 my-1`} {...props}>
                           <CodeBlock
                             key={Math.random()}
+                            messageId={message.id}
                             language={language || "SQL"}
                             value={String(child.props.children).replace(/\n$/, "")}
                             {...props}

--- a/src/components/QueryDrawer.tsx
+++ b/src/components/QueryDrawer.tsx
@@ -32,25 +32,23 @@ const QueryDrawer = () => {
 
     const statement = context?.statement || "";
     setStatement(statement);
+    // Save original statement when open QueryDrawer.
+    if (!originalStatement) {
+      setOriginalStatement(statement);
+    }
+
     if (statement !== "" && checkStatementIsSelect(statement)) {
       executeStatement(statement);
     }
     setExecutionResult(undefined);
   }, [context, queryStore.showDrawer]);
 
-  // Reset old statement when close QueryDrawer.
+  // Reset old statement to "" when close QueryDrawer.
   useEffect(() => {
     if (!queryStore.showDrawer) {
       setOriginalStatement("");
     }
   }, [queryStore.showDrawer]);
-
-  // Save old statement when open QueryDrawer.
-  useEffect(() => {
-    if (!originalStatement) {
-      setOriginalStatement(statement);
-    }
-  }, [statement]);
 
   const executeStatement = async (statement: string) => {
     if (!statement) {

--- a/src/components/QueryDrawer.tsx
+++ b/src/components/QueryDrawer.tsx
@@ -18,6 +18,7 @@ const QueryDrawer = () => {
   const queryStore = useQueryStore();
   const messageStore = useMessageStore();
   const [executionResult, setExecutionResult] = useState<ExecutionResult | undefined>(undefined);
+  const [originalStatement, setOriginalStatement] = useState<string>("");
   const [statement, setStatement] = useState<string>("");
   const [isLoading, setIsLoading] = useState(false);
   const context = queryStore.context;
@@ -36,6 +37,20 @@ const QueryDrawer = () => {
     }
     setExecutionResult(undefined);
   }, [context, queryStore.showDrawer]);
+
+  // Reset old statement when close QueryDrawer.
+  useEffect(() => {
+    if (!queryStore.showDrawer) {
+      setOriginalStatement("");
+    }
+  }, [queryStore.showDrawer]);
+
+  // Save old statement when open QueryDrawer.
+  useEffect(() => {
+    if (!originalStatement) {
+      setOriginalStatement(statement);
+    }
+  }, [statement]);
 
   const executeStatement = async (statement: string) => {
     if (!statement) {
@@ -82,11 +97,14 @@ const QueryDrawer = () => {
     }
   };
 
-  const close = () => queryStore.toggleDrawer(false);
+  const close = () => {
+    if (originalStatement !== statement) {
+      messageStore.updateStatement(context?.messageId || "", originalStatement, statement);
+    }
+    queryStore.toggleDrawer(false);
+  };
 
   const handleSQLChange = (newStatement: string) => {
-    messageStore.updateStatement(context?.messageId || "", statement, newStatement);
-
     setStatement(newStatement);
   };
 

--- a/src/components/QueryDrawer.tsx
+++ b/src/components/QueryDrawer.tsx
@@ -43,7 +43,7 @@ const QueryDrawer = () => {
     setExecutionResult(undefined);
   }, [context, queryStore.showDrawer]);
 
-  // Reset old statement to "" when close QueryDrawer.
+  // Reset original statement to "" when close QueryDrawer.
   useEffect(() => {
     if (!queryStore.showDrawer) {
       setOriginalStatement("");

--- a/src/components/QueryDrawer.tsx
+++ b/src/components/QueryDrawer.tsx
@@ -102,10 +102,6 @@ const QueryDrawer = () => {
     queryStore.toggleDrawer(false);
   };
 
-  const handleSQLChange = (newStatement: string) => {
-    setStatement(newStatement);
-  };
-
   return (
     <Drawer open={queryStore.showDrawer} anchor="right" className="w-full" onClose={close}>
       <div className="dark:text-gray-300 w-screen sm:w-[calc(60vw)] lg:w-[calc(50vw)] 2xl:w-[calc(40vw)] max-w-full flex flex-col justify-start items-start p-4">
@@ -134,7 +130,7 @@ const QueryDrawer = () => {
                 minRows={1}
                 maxRows={5}
                 placeholder="Enter your SQL statement here..."
-                onChange={(e) => handleSQLChange(e.target.value)}
+                onChange={(e) => setStatement(e.target.value)}
               />
               <Tooltip title={t("common.execute")} side="top">
                 <button

--- a/src/components/QueryDrawer.tsx
+++ b/src/components/QueryDrawer.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from "react";
 import { toast } from "react-hot-toast";
 import { useTranslation } from "react-i18next";
 import TextareaAutosize from "react-textarea-autosize";
-import { useQueryStore } from "@/store";
+import { useConversationStore, useQueryStore, useMessageStore } from "@/store";
 import { ExecutionResult, ResponseObject } from "@/types";
 import { checkStatementIsSelect, getMessageFromExecutionResult } from "@/utils";
 import Tooltip from "./kit/Tooltip";
@@ -16,6 +16,7 @@ import ExecutionWarningBanner from "./ExecutionView/ExecutionWarningBanner";
 const QueryDrawer = () => {
   const { t } = useTranslation();
   const queryStore = useQueryStore();
+  const messageStore = useMessageStore();
   const [executionResult, setExecutionResult] = useState<ExecutionResult | undefined>(undefined);
   const [statement, setStatement] = useState<string>("");
   const [isLoading, setIsLoading] = useState(false);
@@ -81,7 +82,15 @@ const QueryDrawer = () => {
     }
   };
 
-  const close = () => queryStore.toggleDrawer(false);
+  const close = () => {
+    // update sql statement
+    queryStore.toggleDrawer(false);
+  };
+  const handleSQLChange = (newStatement: string) => {
+    messageStore.updateStatement(context?.messageId || "", statement, newStatement);
+
+    setStatement(newStatement);
+  };
 
   return (
     <Drawer open={queryStore.showDrawer} anchor="right" className="w-full" onClose={close}>
@@ -111,7 +120,7 @@ const QueryDrawer = () => {
                 minRows={1}
                 maxRows={5}
                 placeholder="Enter your SQL statement here..."
-                onChange={(e) => setStatement(e.target.value)}
+                onChange={(e) => handleSQLChange(e.target.value)}
               />
               <Tooltip title={t("common.execute")} side="top">
                 <button

--- a/src/components/QueryDrawer.tsx
+++ b/src/components/QueryDrawer.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from "react";
 import { toast } from "react-hot-toast";
 import { useTranslation } from "react-i18next";
 import TextareaAutosize from "react-textarea-autosize";
-import { useConversationStore, useQueryStore, useMessageStore } from "@/store";
+import { useQueryStore, useMessageStore } from "@/store";
 import { ExecutionResult, ResponseObject } from "@/types";
 import { checkStatementIsSelect, getMessageFromExecutionResult } from "@/utils";
 import Tooltip from "./kit/Tooltip";
@@ -82,10 +82,8 @@ const QueryDrawer = () => {
     }
   };
 
-  const close = () => {
-    // update sql statement
-    queryStore.toggleDrawer(false);
-  };
+  const close = () => queryStore.toggleDrawer(false);
+
   const handleSQLChange = (newStatement: string) => {
     messageStore.updateStatement(context?.messageId || "", statement, newStatement);
 

--- a/src/store/message.ts
+++ b/src/store/message.ts
@@ -7,7 +7,7 @@ interface MessageState {
   getState: () => MessageState;
   addMessage: (message: Message) => void;
   updateMessage: (messageId: Id, message: Partial<Message>) => void;
-  updateStatement: (messageId: Id, oldStatement: string, newStatement: string) => void;
+  updateStatement: (messageId: Id, originalStatement: string, replacementStatement: string) => void;
   clearMessage: (filter: (message: Message) => boolean) => void;
 }
 
@@ -23,10 +23,11 @@ export const useMessageStore = create<MessageState>()(
           messageList: state.messageList.map((item) => (item.id === messageId ? { ...item, ...message } : item)),
         }));
       },
-      updateStatement: (messageId: Id, oldStatement: string, newStatement: string) => {
+      updateStatement: (messageId: Id, originalStatement: string, replacementStatement: string) => {
+        if (!originalStatement) return;
         const newMessage = get().messageList.find((message) => message.id == messageId);
         if (!newMessage) return;
-        newMessage.content = newMessage.content.replace(oldStatement, newStatement);
+        newMessage.content = newMessage.content.replace(originalStatement, replacementStatement);
         set((state) => ({
           ...state,
           messageList: state.messageList.map((item) => (item.id === messageId ? newMessage : item)),

--- a/src/store/message.ts
+++ b/src/store/message.ts
@@ -7,6 +7,7 @@ interface MessageState {
   getState: () => MessageState;
   addMessage: (message: Message) => void;
   updateMessage: (messageId: Id, message: Partial<Message>) => void;
+  updateStatement: (messageId: Id, oldStatement: string, newStatement: string) => void;
   clearMessage: (filter: (message: Message) => boolean) => void;
 }
 
@@ -20,6 +21,15 @@ export const useMessageStore = create<MessageState>()(
         set((state) => ({
           ...state,
           messageList: state.messageList.map((item) => (item.id === messageId ? { ...item, ...message } : item)),
+        }));
+      },
+      updateStatement: (messageId: Id, oldStatement: string, newStatement: string) => {
+        const newMessage = get().messageList.find((message) => message.id == messageId);
+        if (!newMessage) return;
+        newMessage.content = newMessage.content.replace(oldStatement, newStatement);
+        set((state) => ({
+          ...state,
+          messageList: state.messageList.map((item) => (item.id === messageId ? newMessage : item)),
         }));
       },
       clearMessage: (filter: (message: Message) => boolean) => set((state) => ({ messageList: state.messageList.filter(filter) })),

--- a/src/store/query.ts
+++ b/src/store/query.ts
@@ -1,11 +1,12 @@
 import { merge } from "lodash-es";
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
-import { Connection, Database, Timestamp } from "@/types";
+import { Connection, Database, Id, Timestamp } from "@/types";
 
 interface ExecuteQueryContext {
   connection: Connection;
   database?: Database;
+  messageId?: Id;
   statement: string;
 }
 


### PR DESCRIPTION
close #96

## Update message when changing SQL or when closing the QueryDrawer?
🤔Update message on change text is simplest to implement. Because the program can know the old statement and new statement without any new variables.

Update the message when closing the page. we need an additional variable to record the original statement🤔 But it reduces many unnecessary updates.  I think it is good


![CleanShot 2023-05-21 at 17 00 23](https://github.com/sqlchat/sqlchat/assets/29306285/3278b8f4-a7ce-47ea-8561-45e6489efdaa)
