### PR TITLE
fix: error token num calc

### DIFF
--- a/src/components/ConversationView/index.tsx
+++ b/src/components/ConversationView/index.tsx
@@ -167,7 +167,7 @@ const ConversationView = () => {
         if (tableList) {
           for (const table of tableList) {
             if (tokens < MAX_TOKENS / 2) {
-              tokens += countTextTokens(schema + table);
+              tokens += countTextTokens(table);
               schema += table;
             }
           }


### PR DESCRIPTION
I think the calculation here is wrong
```typescript
        if (tableList) {
          for (const table of tableList) {
            if (tokens < MAX_TOKENS / 2) {
              tokens += countTextTokens(schema + table);
              schema += table;
            }
          }
        }
```
if there are two tables
schema = `table1 + table2`. But the token is `schema + schema + table1 + schema + table2`.
