### PR TITLE
feat: support schema select

### DIFF
--- a/src/components/ConnectionSidebar.tsx
+++ b/src/components/ConnectionSidebar.tsx
@@ -195,7 +195,7 @@ const ConnectionSidebar = () => {
                   />
                 </div>
               )}
-              {currentConnectionCtx?.connection.engineType === Engine.PostgreSQL && schemaList.length > 0 && (
+              {hasSchemaProperty && schemaList.length > 0 && (
                 <Select
                   className="w-full px-4 py-3 !text-base"
                   value={selectedSchemaName}
@@ -206,7 +206,7 @@ const ConnectionSidebar = () => {
                     };
                   })}
                   onValueChange={(schema) => handleSchemaNameSelect(schema)}
-                  placeholder={t("connection.select-database") || ""}
+                  placeholder={t("connection.select-schema") || ""}
                 />
               )}
               {currentConnectionCtx &&

--- a/src/components/ConnectionSidebar.tsx
+++ b/src/components/ConnectionSidebar.tsx
@@ -13,7 +13,7 @@ import QuotaView from "./QuotaView";
 import { hasFeature } from "../utils";
 import MultipleSelect from "./kit/MultipleSelect";
 import SettingAvatarIcon from "./SettingAvatarIcon";
-import { Schema } from "@/types/schema";
+import { Schema } from "@/types";
 
 interface State {}
 

--- a/src/components/ConnectionSidebar.tsx
+++ b/src/components/ConnectionSidebar.tsx
@@ -2,7 +2,7 @@ import { Drawer } from "@mui/material";
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useConnectionStore, useConversationStore, useLayoutStore, ResponsiveWidth, useSettingStore } from "@/store";
-import { Engine, Table } from "@/types";
+import { Engine, Table, Schema } from "@/types";
 import useLoading from "@/hooks/useLoading";
 import Select from "./kit/Select";
 import Icon from "./Icon";
@@ -13,7 +13,6 @@ import QuotaView from "./QuotaView";
 import { hasFeature } from "../utils";
 import MultipleSelect from "./kit/MultipleSelect";
 import SettingAvatarIcon from "./SettingAvatarIcon";
-import { Schema } from "@/types";
 
 interface State {}
 

--- a/src/components/ConnectionSidebar.tsx
+++ b/src/components/ConnectionSidebar.tsx
@@ -27,10 +27,11 @@ const ConnectionSidebar = () => {
   const databaseList = connectionStore.databaseList.filter((database) => database.connectionId === currentConnectionCtx?.connection.id);
   const [tableList, updateTableList] = useState<Table[]>([]);
   const [schemaList, updateSchemaList] = useState<Schema[]>([]);
-  const [selectSchema, updateSelectSchema] = useState<string>("");
   const [hasSchemaProperty, updateHasSchemaProperty] = useState<boolean>(false);
   const selectedTablesName: string[] =
     conversationStore.getConversationById(conversationStore.currentConversationId)?.selectedTablesName || [];
+  const selectedSchemaName: string =
+    conversationStore.getConversationById(conversationStore.currentConversationId)?.selectedSchemaName || "";
   const tableSchemaLoadingState = useLoading();
   const currentConversation = conversationStore.getConversationById(conversationStore.currentConversationId);
 
@@ -88,16 +89,16 @@ const ConnectionSidebar = () => {
 
     updateSchemaList(schemaList);
     if (hasSchemaProperty) {
-      updateSelectSchema(schemaList[0]?.name || "");
+      conversationStore.updateSelectedSchemaName(schemaList[0]?.name || "");
     } else {
-      updateSelectSchema("");
+      conversationStore.updateSelectedSchemaName("");
     }
   }, [connectionStore, currentConnectionCtx]);
 
   useEffect(() => {
-    const tableList = schemaList.find((schema) => schema.name === selectSchema)?.tables || [];
+    const tableList = schemaList.find((schema) => schema.name === selectedSchemaName)?.tables || [];
     updateTableList(tableList);
-  }, [selectSchema]);
+  }, [selectedSchemaName]);
 
   const handleDatabaseNameSelect = async (databaseName: string) => {
     if (!currentConnectionCtx?.connection) {
@@ -191,14 +192,14 @@ const ConnectionSidebar = () => {
               {currentConnectionCtx?.connection.engineType === Engine.PostgreSQL && schemaList.length > 0 && (
                 <Select
                   className="w-full px-4 py-3 !text-base"
-                  value={selectSchema}
+                  value={selectedSchemaName}
                   itemList={schemaList.map((schema) => {
                     return {
                       label: schema.name,
                       value: schema.name,
                     };
                   })}
-                  onValueChange={(schema) => updateSelectSchema(schema)}
+                  onValueChange={(schema) => conversationStore.updateSelectedSchemaName(schema)}
                   placeholder={t("connection.select-database") || ""}
                 />
               )}

--- a/src/components/ConnectionSidebar.tsx
+++ b/src/components/ConnectionSidebar.tsx
@@ -88,12 +88,15 @@ const ConnectionSidebar = () => {
       )?.schemaList || [];
 
     updateSchemaList(schemaList);
+    // need to create a conversation. otherwise updateSelectedSchemaName will failed.
+    createConversation();
     if (hasSchemaProperty) {
       conversationStore.updateSelectedSchemaName(schemaList[0]?.name || "");
+      console.log("update", schemaList[0]?.name || "");
     } else {
       conversationStore.updateSelectedSchemaName("");
     }
-  }, [connectionStore, currentConnectionCtx]);
+  }, [connectionStore, currentConnectionCtx, schemaList]);
 
   useEffect(() => {
     const tableList = schemaList.find((schema) => schema.name === selectedSchemaName)?.tables || [];
@@ -137,15 +140,16 @@ const ConnectionSidebar = () => {
     conversationStore.updateSelectedTablesName(selectedTablesName);
   };
 
-  // const handleAllSelect = async () => {
-  //   createConversation();
-  //   conversationStore.updateSelectedTablesName(tableList.map((table) => table.name));
-  // };
+  const handleAllSelect = async () => {
+    createConversation();
+    conversationStore.updateSelectedTablesName(tableList.map((table) => table.name));
+  };
 
   const handleEmptySelect = async () => {
     createConversation();
     conversationStore.updateSelectedTablesName([]);
   };
+
   return (
     <>
       <Drawer

--- a/src/components/ConnectionSidebar.tsx
+++ b/src/components/ConnectionSidebar.tsx
@@ -14,6 +14,7 @@ import { hasFeature } from "../utils";
 import MultipleSelect from "./kit/MultipleSelect";
 import SettingAvatarIcon from "./SettingAvatarIcon";
 import { Schema } from "@/types/schema";
+
 interface State {}
 
 const ConnectionSidebar = () => {
@@ -92,16 +93,15 @@ const ConnectionSidebar = () => {
     createConversation();
     if (hasSchemaProperty) {
       conversationStore.updateSelectedSchemaName(schemaList[0]?.name || "");
-      console.log("update", schemaList[0]?.name || "");
     } else {
       conversationStore.updateSelectedSchemaName("");
     }
-  }, [connectionStore, currentConnectionCtx, schemaList]);
+  }, [connectionStore, hasSchemaProperty, currentConnectionCtx, schemaList]);
 
   useEffect(() => {
     const tableList = schemaList.find((schema) => schema.name === selectedSchemaName)?.tables || [];
     updateTableList(tableList);
-  }, [selectedSchemaName]);
+  }, [selectedSchemaName, selectedTablesName, schemaList]);
 
   const handleDatabaseNameSelect = async (databaseName: string) => {
     if (!currentConnectionCtx?.connection) {
@@ -136,18 +136,21 @@ const ConnectionSidebar = () => {
   };
 
   const handleTableNameSelect = async (selectedTablesName: string[]) => {
-    createConversation();
     conversationStore.updateSelectedTablesName(selectedTablesName);
   };
 
   const handleAllSelect = async () => {
-    createConversation();
     conversationStore.updateSelectedTablesName(tableList.map((table) => table.name));
   };
 
   const handleEmptySelect = async () => {
-    createConversation();
     conversationStore.updateSelectedTablesName([]);
+  };
+
+  const handleSchemaNameSelect = async (schemaName: string) => {
+    // need to empty selectedTablesName when schemaName changed. because selectedTablesName may not exist in new schema.
+    conversationStore.updateSelectedTablesName([]);
+    conversationStore.updateSelectedSchemaName(schemaName);
   };
 
   return (
@@ -203,7 +206,7 @@ const ConnectionSidebar = () => {
                       value: schema.name,
                     };
                   })}
-                  onValueChange={(schema) => conversationStore.updateSelectedSchemaName(schema)}
+                  onValueChange={(schema) => handleSchemaNameSelect(schema)}
                   placeholder={t("connection.select-database") || ""}
                 />
               )}

--- a/src/components/ConversationView/index.tsx
+++ b/src/components/ConversationView/index.tsx
@@ -153,7 +153,7 @@ const ConversationView = () => {
         const schemaList = await connectionStore.getOrFetchDatabaseSchema(connectionStore.currentConnectionCtx?.database);
         // Empty table name(such as []) denote all table. [] and `undefined` both are false in `if`
         const tableList: string[] = [];
-        const selectedSchema = schemaList.find((schema) => schema.name == (currentConversation.selectedTablesName || ""));
+        const selectedSchema = schemaList.find((schema) => schema.name == (currentConversation.selectedSchemaName || ""));
         if (currentConversation.selectedTablesName) {
           currentConversation.selectedTablesName.forEach((tableName: string) => {
             const table = selectedSchema?.tables.find((table) => table.name == tableName);

--- a/src/components/ConversationView/index.tsx
+++ b/src/components/ConversationView/index.tsx
@@ -150,17 +150,17 @@ const ConversationView = () => {
     if (connectionStore.currentConnectionCtx?.database) {
       let schema = "";
       try {
-        const tables = await connectionStore.getOrFetchDatabaseSchema(connectionStore.currentConnectionCtx?.database);
+        const schemaList = await connectionStore.getOrFetchDatabaseSchema(connectionStore.currentConnectionCtx?.database);
         // Empty table name(such as []) denote all table. [] and `undefined` both are false in `if`
-
         const tableList: string[] = [];
+        const selectedSchema = schemaList.find((schema) => schema.name == (currentConversation.selectedTablesName || ""));
         if (currentConversation.selectedTablesName) {
           currentConversation.selectedTablesName.forEach((tableName: string) => {
-            const table = tables.find((table) => table.name === tableName);
+            const table = selectedSchema?.tables.find((table) => table.name == tableName);
             tableList.push(table!.structure);
           });
         } else {
-          for (const table of tables) {
+          for (const table of selectedSchema?.tables || []) {
             tableList.push(table!.structure);
           }
         }

--- a/src/lib/connectors/index.ts
+++ b/src/lib/connectors/index.ts
@@ -2,7 +2,7 @@ import { Connection, Engine, ExecutionResult } from "@/types";
 import mysql from "./mysql";
 import postgres from "./postgres";
 import mssql from "./mssql";
-import { Schema } from "@/types/schema";
+import { Schema } from "@/types";
 
 export interface Connector {
   testConnection: () => Promise<boolean>;

--- a/src/lib/connectors/index.ts
+++ b/src/lib/connectors/index.ts
@@ -2,12 +2,13 @@ import { Connection, Engine, ExecutionResult } from "@/types";
 import mysql from "./mysql";
 import postgres from "./postgres";
 import mssql from "./mssql";
+import { Schema } from "@/types/schema";
 
 export interface Connector {
   testConnection: () => Promise<boolean>;
   execute: (databaseName: string, statement: string) => Promise<ExecutionResult>;
   getDatabases: () => Promise<string[]>;
-  getTables: (databaseName: string) => Promise<string[]>;
+  getTables: (databaseName: string) => Promise<string[] | Schema[]>;
   getTableStructure: (
     databaseName: string,
     tableName: string,
@@ -18,7 +19,7 @@ export interface Connector {
     tableNameList: string[],
     structureFetched: (tableName: string, structure: string) => void
   ) => Promise<void>;
-  getSchema?: (databaseName: string) => Promise<string[]>;
+  getTableSchema: (databaseName: string) => Promise<Schema[]>;
 }
 
 export const newConnector = (connection: Connection): Connector => {

--- a/src/lib/connectors/index.ts
+++ b/src/lib/connectors/index.ts
@@ -18,6 +18,7 @@ export interface Connector {
     tableNameList: string[],
     structureFetched: (tableName: string, structure: string) => void
   ) => Promise<void>;
+  getSchema?: (databaseName: string) => Promise<string[]>;
 }
 
 export const newConnector = (connection: Connection): Connector => {

--- a/src/lib/connectors/index.ts
+++ b/src/lib/connectors/index.ts
@@ -1,8 +1,7 @@
-import { Connection, Engine, ExecutionResult } from "@/types";
+import { Connection, Engine, ExecutionResult, Schema } from "@/types";
 import mysql from "./mysql";
 import postgres from "./postgres";
 import mssql from "./mssql";
-import { Schema } from "@/types";
 
 export interface Connector {
   testConnection: () => Promise<boolean>;

--- a/src/lib/connectors/index.ts
+++ b/src/lib/connectors/index.ts
@@ -7,17 +7,6 @@ export interface Connector {
   testConnection: () => Promise<boolean>;
   execute: (databaseName: string, statement: string) => Promise<ExecutionResult>;
   getDatabases: () => Promise<string[]>;
-  getTables: (databaseName: string) => Promise<string[] | Schema[]>;
-  getTableStructure: (
-    databaseName: string,
-    tableName: string,
-    structureFetched: (tableName: string, structure: string) => void
-  ) => Promise<void>;
-  getTableStructureBatch: (
-    databaseName: string,
-    tableNameList: string[],
-    structureFetched: (tableName: string, structure: string) => void
-  ) => Promise<void>;
   getTableSchema: (databaseName: string) => Promise<Schema[]>;
 }
 

--- a/src/lib/connectors/mssql/index.ts
+++ b/src/lib/connectors/mssql/index.ts
@@ -1,7 +1,6 @@
 import { ConnectionPool } from "mssql";
-import { Connection, ExecutionResult } from "@/types";
+import { Connection, ExecutionResult, Schema } from "@/types";
 import { Connector } from "..";
-import { Schema } from "@/types";
 
 const systemDatabases = ["master", "tempdb", "model", "msdb"];
 

--- a/src/lib/connectors/mssql/index.ts
+++ b/src/lib/connectors/mssql/index.ts
@@ -1,6 +1,7 @@
 import { ConnectionPool } from "mssql";
 import { Connection, ExecutionResult } from "@/types";
 import { Connector } from "..";
+import { Schema } from "@/types/schema";
 
 const systemDatabases = ["master", "tempdb", "model", "msdb"];
 
@@ -133,6 +134,10 @@ const getTableStructureBatch = async (
   );
 };
 
+const getTableSchema = async (connection: Connection, databaseName: string): Promise<Schema[]> => {
+  return [];
+};
+
 const newConnector = (connection: Connection): Connector => {
   return {
     testConnection: () => testConnection(connection),
@@ -146,6 +151,7 @@ const newConnector = (connection: Connection): Connector => {
       tableNameList: string[],
       structureFetched: (tableName: string, structure: string) => void
     ) => getTableStructureBatch(connection, databaseName, tableNameList, structureFetched),
+    getTableSchema: (databaseName: string) => getTableSchema(connection, databaseName),
   };
 };
 

--- a/src/lib/connectors/mssql/index.ts
+++ b/src/lib/connectors/mssql/index.ts
@@ -1,7 +1,7 @@
 import { ConnectionPool } from "mssql";
 import { Connection, ExecutionResult } from "@/types";
 import { Connector } from "..";
-import { Schema } from "@/types/schema";
+import { Schema } from "@/types";
 
 const systemDatabases = ["master", "tempdb", "model", "msdb"];
 

--- a/src/lib/connectors/mssql/index.ts
+++ b/src/lib/connectors/mssql/index.ts
@@ -85,7 +85,6 @@ const getTableSchema = async (connection: Connection, databaseName: string): Pro
       const { recordset } = await request.query(
         `SELECT COLUMN_NAME, DATA_TYPE, IS_NULLABLE FROM ${databaseName}.INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA='${schema.name}' AND TABLE_NAME='${table.name}';`
       );
-      console.log(recordset);
       const columnList = [];
       // Transform to standard schema string.
       for (const row of recordset) {

--- a/src/lib/connectors/mysql/index.ts
+++ b/src/lib/connectors/mysql/index.ts
@@ -1,8 +1,7 @@
 import { ConnectionOptions } from "mysql2";
 import mysql, { RowDataPacket } from "mysql2/promise";
-import { Connection, ExecutionResult, Table } from "@/types";
+import { Connection, ExecutionResult, Table, Schema } from "@/types";
 import { Connector } from "..";
-import { Schema } from "@/types";
 
 const systemDatabases = ["information_schema", "mysql", "performance_schema", "sys"];
 

--- a/src/lib/connectors/mysql/index.ts
+++ b/src/lib/connectors/mysql/index.ts
@@ -2,7 +2,7 @@ import { ConnectionOptions } from "mysql2";
 import mysql, { RowDataPacket } from "mysql2/promise";
 import { Connection, ExecutionResult, Table } from "@/types";
 import { Connector } from "..";
-import { Schema } from "@/types/schema";
+import { Schema } from "@/types";
 
 const systemDatabases = ["information_schema", "mysql", "performance_schema", "sys"];
 

--- a/src/lib/connectors/postgres/index.ts
+++ b/src/lib/connectors/postgres/index.ts
@@ -1,7 +1,6 @@
 import { Client, ClientConfig } from "pg";
-import { Connection, ExecutionResult, Table } from "@/types";
+import { Connection, ExecutionResult, Table, Schema } from "@/types";
 import { Connector } from "..";
-import { Schema } from "@/types";
 
 const systemSchemas =
   "'information_schema', 'pg_catalog', 'pg_toast', '_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_internal', '_timescaledb_config', 'timescaledb_information', 'timescaledb_experimental'";

--- a/src/lib/connectors/postgres/index.ts
+++ b/src/lib/connectors/postgres/index.ts
@@ -158,6 +158,22 @@ const getTableStructureBatch = async (
   });
 };
 
+const getSchema = async (connection: Connection, databaseName: string): Promise<Array<string>> => {
+  connection.database = databaseName;
+  const client = await newPostgresClient(connection);
+  const { rows } = await client.query(
+    `SELECT nspname
+    FROM pg_catalog.pg_namespace
+    WHERE nspname NOT IN (${systemSchemas});
+    `
+  );
+  console.log(`SELECT nspname
+  FROM pg_catalog.pg_namespace
+  WHERE nspname NOT IN (${systemSchemas});
+  `);
+
+  return [];
+};
 const newConnector = (connection: Connection): Connector => {
   return {
     testConnection: () => testConnection(connection),
@@ -171,6 +187,7 @@ const newConnector = (connection: Connection): Connector => {
       tableNameList: string[],
       structureFetched: (tableName: string, structure: string) => void
     ) => getTableStructureBatch(connection, databaseName, tableNameList, structureFetched),
+    getSchema: (databaseName: string) => getSchema(connection, databaseName),
   };
 };
 

--- a/src/lib/connectors/postgres/index.ts
+++ b/src/lib/connectors/postgres/index.ts
@@ -1,7 +1,7 @@
 import { Client, ClientConfig } from "pg";
 import { Connection, ExecutionResult, Table } from "@/types";
 import { Connector } from "..";
-import { Schema } from "@/types/schema";
+import { Schema } from "@/types";
 
 const systemSchemas =
   "'information_schema', 'pg_catalog', 'pg_toast', '_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_internal', '_timescaledb_config', 'timescaledb_information', 'timescaledb_experimental'";

--- a/src/lib/connectors/postgres/index.ts
+++ b/src/lib/connectors/postgres/index.ts
@@ -116,7 +116,6 @@ const getTables = async (connection: Connection, databaseName: string): Promise<
       }
     }
   }
-  console.log(schemaList);
   return schemaList;
 };
 
@@ -223,7 +222,6 @@ const getTableSchema = async (connection: Connection, databaseName: string): Pro
   }
 
   await client.end();
-  console.log(schemaList);
   return schemaList;
   return [];
 };

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -30,6 +30,7 @@
     "edit": "Edit Connection",
     "select-database": "Select your database",
     "select-table": "Select your table",
+    "select-schema": "Select your Schema",
     "all-tables": "All Tables",
     "database-type": "Database type",
     "title": "Title",

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -30,6 +30,7 @@
     "edit": "编辑连接",
     "select-database": "选择数据库",
     "select-table": "选择数据表",
+    "select-schema": "选择 Schema",
     "all-tables": "全部表",
     "select-all": "选择全部",
     "empty-select": "清空选择",

--- a/src/pages/api/connection/db_schema.ts
+++ b/src/pages/api/connection/db_schema.ts
@@ -1,13 +1,8 @@
 import { NextApiRequest, NextApiResponse } from "next";
 import { newConnector } from "@/lib/connectors";
-import { Connection, Table } from "@/types";
+import { Connection, Schema } from "@/types";
 import { changeTiDBConnectionToMySQL } from "@/utils";
 import { Engine } from "@/types/connection";
-import { Schema } from "@/types";
-
-function isStringArray(x: any[]): x is string[] {
-  return x.every((i) => typeof i === "string");
-}
 
 // POST /api/connection/db_schema
 // req body: { connection: Connection, db: string }

--- a/src/pages/api/connection/db_schema.ts
+++ b/src/pages/api/connection/db_schema.ts
@@ -3,7 +3,7 @@ import { newConnector } from "@/lib/connectors";
 import { Connection, Table } from "@/types";
 import { changeTiDBConnectionToMySQL } from "@/utils";
 import { Engine } from "@/types/connection";
-import { Schema } from "@/types/schema";
+import { Schema } from "@/types";
 
 function isStringArray(x: any[]): x is string[] {
   return x.every((i) => typeof i === "string");

--- a/src/pages/api/connection/db_schema.ts
+++ b/src/pages/api/connection/db_schema.ts
@@ -3,7 +3,11 @@ import { newConnector } from "@/lib/connectors";
 import { Connection, Table } from "@/types";
 import { changeTiDBConnectionToMySQL } from "@/utils";
 import { Engine } from "@/types/connection";
-import { raw } from "mysql2";
+import { Schema } from "@/types/schema";
+
+function isStringArray(x: any[]): x is string[] {
+  return x.every((i) => typeof i === "string");
+}
 
 // POST /api/connection/db_schema
 // req body: { connection: Connection, db: string }
@@ -22,24 +26,10 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
 
   try {
     const connector = newConnector(connection);
-    const tableStructures: Table[] = [];
-    const rawTableNameList = await connector.getTables(db);
-    if (connection.engineType === Engine.PostgreSQL) {
-      if (connector.getSchema) {
-        const rawSchema = await connector.getSchema(db);
-        console.log(rawSchema);
-      }
-    }
-    const structureFetched = (tableName: string, structure: string) => {
-      tableStructures.push({
-        name: tableName,
-        structure,
-      });
-    };
-    await connector.getTableStructureBatch(db, rawTableNameList, structureFetched);
+    const schemaList: Schema[] = await connector.getTableSchema(db);
 
     res.status(200).json({
-      data: tableStructures,
+      data: schemaList,
     });
   } catch (error: any) {
     res.status(400).json({

--- a/src/pages/api/connection/db_schema.ts
+++ b/src/pages/api/connection/db_schema.ts
@@ -3,6 +3,7 @@ import { newConnector } from "@/lib/connectors";
 import { Connection, Table } from "@/types";
 import { changeTiDBConnectionToMySQL } from "@/utils";
 import { Engine } from "@/types/connection";
+import { raw } from "mysql2";
 
 // POST /api/connection/db_schema
 // req body: { connection: Connection, db: string }
@@ -18,10 +19,17 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
   }
 
   const db = req.body.db as string;
+
   try {
     const connector = newConnector(connection);
     const tableStructures: Table[] = [];
     const rawTableNameList = await connector.getTables(db);
+    if (connection.engineType === Engine.PostgreSQL) {
+      if (connector.getSchema) {
+        const rawSchema = await connector.getSchema(db);
+        console.log(rawSchema);
+      }
+    }
     const structureFetched = (tableName: string, structure: string) => {
       tableStructures.push({
         name: tableName,

--- a/src/store/connection.ts
+++ b/src/store/connection.ts
@@ -142,13 +142,8 @@ export const useConnectionStore = create<ConnectionState>()(
       migrate: (persistedState: any, version: number) => {
         let state = persistedState as ConnectionState;
         if (version === 0 || version === undefined) {
-          // Migration from v0 to v1
-          for (const connection of state.connectionList) {
-            if (state.currentConnectionCtx?.database) {
-              console.log("更新了", state.currentConnectionCtx?.database);
-              state.getOrFetchDatabaseSchema(state.currentConnectionCtx?.database, true);
-            }
-          }
+          // to clear old data. it will make refetch new schema List
+          state.databaseList = [];
         }
         return state;
       },

--- a/src/store/connection.ts
+++ b/src/store/connection.ts
@@ -2,10 +2,8 @@ import axios from "axios";
 import { uniqBy } from "lodash-es";
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
-import { Connection, Database, Engine, ResponseObject, Table } from "@/types";
+import { Connection, Database, Engine, ResponseObject, Schema } from "@/types";
 import { generateUUID } from "@/utils";
-import { Schema } from "@/types";
-import { stat } from "fs";
 
 interface ConnectionContext {
   connection: Connection;

--- a/src/store/connection.ts
+++ b/src/store/connection.ts
@@ -70,7 +70,6 @@ export const useConnectionStore = create<ConnectionState>()(
           connection,
         });
 
-        console.log("fetch db", data);
         const fetchedDatabaseList = data.map(
           (dbName) =>
             ({
@@ -108,8 +107,6 @@ export const useConnectionStore = create<ConnectionState>()(
           connection,
           db: database.name,
         });
-
-        console.log("fetch db_schema", result);
 
         if (result.message) {
           throw result.message;

--- a/src/store/connection.ts
+++ b/src/store/connection.ts
@@ -5,6 +5,7 @@ import { persist } from "zustand/middleware";
 import { Connection, Database, Engine, ResponseObject, Table } from "@/types";
 import { generateUUID } from "@/utils";
 import { Schema } from "@/types/schema";
+import { stat } from "fs";
 
 interface ConnectionContext {
   connection: Connection;
@@ -142,6 +143,20 @@ export const useConnectionStore = create<ConnectionState>()(
     }),
     {
       name: "connection-storage",
+      version: 1,
+      migrate: (persistedState: any, version: number) => {
+        let state = persistedState as ConnectionState;
+        if (version === 0 || version === undefined) {
+          // Migration from v0 to v1
+          for (const connection of state.connectionList) {
+            if (state.currentConnectionCtx?.database) {
+              console.log("更新了", state.currentConnectionCtx?.database);
+              state.getOrFetchDatabaseSchema(state.currentConnectionCtx?.database, true);
+            }
+          }
+        }
+        return state;
+      },
     }
   )
 );

--- a/src/store/connection.ts
+++ b/src/store/connection.ts
@@ -142,8 +142,11 @@ export const useConnectionStore = create<ConnectionState>()(
       migrate: (persistedState: any, version: number) => {
         let state = persistedState as ConnectionState;
         if (version === 0 || version === undefined) {
+          console.info(`migrate from ${version} to 1`);
+          console.info(state);
           // to clear old data. it will make refetch new schema List
           state.databaseList = [];
+          console.info(state);
         }
         return state;
       },

--- a/src/store/connection.ts
+++ b/src/store/connection.ts
@@ -4,7 +4,7 @@ import { create } from "zustand";
 import { persist } from "zustand/middleware";
 import { Connection, Database, Engine, ResponseObject, Table } from "@/types";
 import { generateUUID } from "@/utils";
-import { Schema } from "@/types/schema";
+import { Schema } from "@/types";
 import { stat } from "fs";
 
 interface ConnectionContext {

--- a/src/store/connection.ts
+++ b/src/store/connection.ts
@@ -141,12 +141,10 @@ export const useConnectionStore = create<ConnectionState>()(
       version: 1,
       migrate: (persistedState: any, version: number) => {
         let state = persistedState as ConnectionState;
-        if (version === 0 || version === undefined) {
+        if (version === 0) {
           console.info(`migrate from ${version} to 1`);
-          console.info(state);
           // to clear old data. it will make refetch new schema List
           state.databaseList = [];
-          console.info(state);
         }
         return state;
       },

--- a/src/store/conversation.ts
+++ b/src/store/conversation.ts
@@ -24,6 +24,7 @@ interface ConversationState {
   updateConversation: (conversationId: Id, conversation: Partial<Conversation>) => void;
   clearConversation: (filter: (conversation: Conversation) => boolean) => void;
   updateSelectedTablesName: (selectedTablesName: string[]) => void;
+  updateSelectedSchemaName: (selectedSchemaName: string) => void;
 }
 
 export const useConversationStore = create<ConversationState>()(
@@ -69,6 +70,14 @@ export const useConversationStore = create<ConversationState>()(
         if (currentConversation) {
           get().updateConversation(currentConversation.id, {
             selectedTablesName,
+          });
+        }
+      },
+      updateSelectedSchemaName: (selectedSchemaName: string) => {
+        const currentConversation = get().getConversationById(get().currentConversationId);
+        if (currentConversation) {
+          get().updateConversation(currentConversation.id, {
+            selectedSchemaName,
           });
         }
       },

--- a/src/types/conversation.ts
+++ b/src/types/conversation.ts
@@ -5,6 +5,7 @@ export interface Conversation {
   connectionId?: Id;
   databaseName?: string;
   selectedTablesName?: string[];
+  selectedSchemaName?: string;
   assistantId: Id;
   title: string;
   createdAt: Timestamp;

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -1,9 +1,9 @@
 import { Id } from ".";
-
+import { Schema } from "./schema";
 export interface Database {
   connectionId: Id;
   name: string;
-  tableList: Table[];
+  schemaList: Schema[];
 }
 
 export interface Table {

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -1,5 +1,4 @@
 import { Id } from ".";
-import { Schema } from "./schema";
 export interface Database {
   connectionId: Id;
   name: string;
@@ -11,4 +10,8 @@ export interface Table {
   // structure is a string of the table structure.
   // It's mainly used for providing a chat context for the assistant.
   structure: string;
+}
+export interface Schema {
+  name: string;
+  tables: Table[];
 }

--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -1,6 +1,0 @@
-import { Table } from ".";
-
-export interface Schema {
-  name: string;
-  tables: Table[];
-}

--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -1,0 +1,6 @@
+import { Table } from ".";
+
+export interface Schema {
+  name: string;
+  tables: Table[];
+}


### PR DESCRIPTION
closes #113 and #111
The PR break the compatibility of `connection-storage` of Local Storage. But I think it is necessary. and discuss in #111 🤔 we need to migrate state. The good news is it is easy to implement and have an experience like https://github.com/sqlchat/sqlchat/blob/main/src/store/conversation.ts#L79

It can insensitive for user😋

for implementing schema for some databases. the data struct must do some changes 👀 Just a little change that doesn't break compatibility or a big change with a better design? 🤔 I think a lot and dive into the source code of bytebase.

I think the solution of bytebase to resolve this problem is very good. and the data struct is familiar to other developers of SQL Chat.

👀 I didn't read more source code of other SQL Clients to find any better solution.But I believe the developer of bytebase has done it. 🤣 So I didn't need to read more and the solution is the best.

![CleanShot 2023-05-27 at 18 20 47](https://github.com/sqlchat/sqlchat/assets/29306285/f94741ab-36a2-45a5-ad58-257cb4bdd7a9)


## What does the PR do?
- refactor `tableList` as `schemaList`
- refactor `connector`, adding `getTableSchema` to replace `getTableStructureBatch`,`getTableStructure` and `getTables`.
- create a conversation if it didn't present after creating a connect. (because we need a default `selectedSchemaName` and it is saved in conversation)
- migrate function to clear old `tableList` data in localStorage.
- fix mssql struct error #113 
