### PR TITLE
fix: always jump to bottom when scroll

### DIFF
--- a/src/components/ConnectionSidebar.tsx
+++ b/src/components/ConnectionSidebar.tsx
@@ -111,7 +111,7 @@ const ConnectionSidebar = () => {
     } else {
       conversationStore.updateSelectedSchemaName("");
     }
-  }, [connectionStore, hasSchemaProperty, currentConnectionCtx, schemaList]);
+  }, [connectionStore, hasSchemaProperty, currentConnectionCtx]);
 
   useEffect(() => {
     const tableList = schemaList.find((schema) => schema.name === selectedSchemaName)?.tables || [];
@@ -141,11 +141,15 @@ const ConnectionSidebar = () => {
   // Note: This function is used to solve issue #95
   //       https://github.com/sqlchat/sqlchat/issues/95
   const createConversation = () => {
+    console.log("wqe");
     if (!currentConversation) {
+      console.log("wqe");
       if (!currentConnectionCtx) {
         conversationStore.createConversation();
+        console.log("1");
       } else {
         conversationStore.createConversation(currentConnectionCtx.connection.id, currentConnectionCtx.database?.name);
+        console.log("2");
       }
     }
   };

--- a/src/components/ConnectionSidebar.tsx
+++ b/src/components/ConnectionSidebar.tsx
@@ -141,15 +141,11 @@ const ConnectionSidebar = () => {
   // Note: This function is used to solve issue #95
   //       https://github.com/sqlchat/sqlchat/issues/95
   const createConversation = () => {
-    console.log("wqe");
     if (!currentConversation) {
-      console.log("wqe");
       if (!currentConnectionCtx) {
         conversationStore.createConversation();
-        console.log("1");
       } else {
         conversationStore.createConversation(currentConnectionCtx.connection.id, currentConnectionCtx.database?.name);
-        console.log("2");
       }
     }
   };

--- a/src/components/ConversationView/index.tsx
+++ b/src/components/ConversationView/index.tsx
@@ -77,7 +77,7 @@ const ConversationView = () => {
       return;
     }
     conversationViewRef.current.scrollTop = conversationViewRef.current.scrollHeight;
-  }, [lastMessage?.id]);
+  }, [currentConversation, lastMessage?.id]);
 
   useEffect(() => {
     if (!conversationViewRef.current) {

--- a/src/components/ConversationView/index.tsx
+++ b/src/components/ConversationView/index.tsx
@@ -77,7 +77,7 @@ const ConversationView = () => {
       return;
     }
     conversationViewRef.current.scrollTop = conversationViewRef.current.scrollHeight;
-  }, [currentConversation, lastMessage?.id]);
+  }, [lastMessage?.id]);
 
   useEffect(() => {
     if (!conversationViewRef.current) {


### PR DESCRIPTION
The Bug seem caused by 
```typescript
  useEffect(() => {
    if (!conversationViewRef.current) {
      return;
    }
    conversationViewRef.current.scrollTop = conversationViewRef.current.scrollHeight;
  }, [currentConversation, lastMessage?.id]);
```
`currentConversation` is always  update🤔 So Why does it update stopless?
In finally, I found the `useEffect` is deps an error variable. the Bug is fixed after deleting it.

👀This error only appears for conversations that are not connected to a database. So the previous test did not find it out.