### PR TITLE
fix: add selected border for conversation Tab for dark mode

### DIFF
--- a/src/components/ConversationTabsView.tsx
+++ b/src/components/ConversationTabsView.tsx
@@ -21,7 +21,7 @@ const ConversationTab = (props: ConversationTabProps) => {
   return (
     <div
       className={`shrink-0 flex flex-row justify-center items-center cursor-pointer text-sm border pl-4 pr-2 py-1 rounded-sm text-gray-600 dark:text-gray-400 hover:text-gray-700 hover:bg-gray-50 dark:hover:bg-zinc-700 dark:border-zinc-700 ${
-        selected && "!border-zinc-700 shadow"
+        selected && "!border-zinc-700 dark:!border-gray-200 shadow"
       }`}
       onClick={() => onClick(conversation)}
     >


### PR DESCRIPTION
![CleanShot 2023-06-01 at 19 36 40@2x](https://github.com/sqlchat/sqlchat/assets/29306285/a21cbab2-2aa5-41fb-abd1-03449b4b3d6d)
![CleanShot 2023-06-01 at 19 36 45@2x](https://github.com/sqlchat/sqlchat/assets/29306285/8d811592-cce2-4a70-91e6-95bc3e85c9b8)

now:
<img width="317" alt="CleanShot 2023-06-01 at 19 39 28@2x" src="https://github.com/sqlchat/sqlchat/assets/29306285/f4cf6c02-8b4e-4594-befe-f736134c2349">
