### PR TITLE
feat: show read-only prompt

### DIFF
--- a/src/components/CodeBlock.tsx
+++ b/src/components/CodeBlock.tsx
@@ -12,10 +12,11 @@ interface Props {
   language: string;
   value: string;
   messageId: Id;
+  wrapLongLines?: boolean;
 }
 
 export const CodeBlock = (props: Props) => {
-  const { language, value, messageId } = props;
+  const { language, value, messageId, wrapLongLines } = props;
   const { t } = useTranslation();
   const connectionStore = useConnectionStore();
   const queryStore = useQueryStore();
@@ -70,7 +71,12 @@ export const CodeBlock = (props: Props) => {
           )}
         </div>
       </div>
-      <SyntaxHighlighter language={language.toLowerCase()} style={oneDark} customStyle={{ margin: 0 }}>
+      <SyntaxHighlighter
+        language={language.toLowerCase()}
+        wrapLongLines={wrapLongLines || false}
+        style={oneDark}
+        customStyle={{ margin: 0 }}
+      >
         {value}
       </SyntaxHighlighter>
     </div>

--- a/src/components/ConversationView/Header.tsx
+++ b/src/components/ConversationView/Header.tsx
@@ -51,19 +51,9 @@ const Header = (props: Props) => {
               />
             </a>
           </span>
-          <div className="mr-2 relative flex flex-row justify-end items-center">
-            {hasFeature("debug") && (
-              <button className="p-2 rounded cursor-pointer hover:bg-gray-100 dark:hover:bg-zinc-700">
-                <Icon.FiSettings className="w-4 h-auto" onClick={() => setShowSchemaDrawer(true)} />
-              </button>
-            )}
-          </div>
         </div>
-
         <ConversationTabsView />
       </div>
-
-      {hasFeature("debug") && showSchemaDrawer && <SchemaDrawer close={() => setShowSchemaDrawer(false)} />}
     </>
   );
 };

--- a/src/components/ConversationView/MessageView.tsx
+++ b/src/components/ConversationView/MessageView.tsx
@@ -1,6 +1,6 @@
 import dayjs from "dayjs";
 import { useSession } from "next-auth/react";
-import { ReactElement } from "react";
+import { ReactElement, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { toast } from "react-hot-toast";
 import ReactMarkdown from "react-markdown";

--- a/src/components/ConversationView/index.tsx
+++ b/src/components/ConversationView/index.tsx
@@ -22,6 +22,8 @@ import MessageView from "./MessageView";
 import ClearConversationButton from "../ClearConversationButton";
 import MessageTextarea from "./MessageTextarea";
 import DataStorageBanner from "../DataStorageBanner";
+import SchemaDrawer from "../SchemaDrawer";
+import Icon from "../Icon";
 
 const ConversationView = () => {
   const { data: session } = useSession();
@@ -39,6 +41,7 @@ const ConversationView = () => {
     ? messageStore.messageList.filter((message: Message) => message.conversationId === currentConversation.id)
     : [];
   const lastMessage = last(messageList);
+  const [showSchemaDrawer, setShowSchemaDrawer] = useState<boolean>(false);
 
   useEffect(() => {
     messageStore.messageList.map((message: Message) => {
@@ -342,6 +345,14 @@ const ConversationView = () => {
       <div className="sticky bottom-0 flex flex-row justify-center items-center w-full max-w-4xl py-2 pb-4 px-4 sm:px-8 mx-auto bg-white dark:bg-zinc-800 bg-opacity-80 backdrop-blur">
         <ClearConversationButton />
         <MessageTextarea disabled={lastMessage?.status === "LOADING"} sendMessage={sendMessageToCurrentConversation} />
+        <div className="mr-2 relative flex flex-row justify-end items-center">
+          {hasFeature("debug") && (
+            <button className="p-2 rounded cursor-pointer hover:bg-gray-100 dark:hover:bg-zinc-700">
+              <Icon.FiSettings className="w-4 h-auto" onClick={() => setShowSchemaDrawer(true)} />
+            </button>
+          )}
+        </div>
+        {hasFeature("debug") && showSchemaDrawer && <SchemaDrawer close={() => setShowSchemaDrawer(false)} />}
       </div>
     </div>
   );

--- a/src/components/ConversationView/index.tsx
+++ b/src/components/ConversationView/index.tsx
@@ -42,7 +42,7 @@ const ConversationView = () => {
     : [];
   const lastMessage = last(messageList);
   const [showSchemaDrawer, setShowSchemaDrawer] = useState<boolean>(false);
-
+  console.log(showHeaderShadow);
   useEffect(() => {
     messageStore.messageList.map((message: Message) => {
       if (message.status === "LOADING") {
@@ -345,10 +345,10 @@ const ConversationView = () => {
       <div className="sticky bottom-0 flex flex-row justify-center items-center w-full max-w-4xl py-2 pb-4 px-4 sm:px-8 mx-auto bg-white dark:bg-zinc-800 bg-opacity-80 backdrop-blur">
         <ClearConversationButton />
         <MessageTextarea disabled={lastMessage?.status === "LOADING"} sendMessage={sendMessageToCurrentConversation} />
-        <div className="mr-2 relative flex flex-row justify-end items-center">
+        <div className="mr-2 relative flex flex-row justify-end items-center" onClick={() => setShowSchemaDrawer(true)}>
           {hasFeature("debug") && (
             <button className="p-2 rounded cursor-pointer hover:bg-gray-100 dark:hover:bg-zinc-700">
-              <Icon.FiSettings className="w-4 h-auto" onClick={() => setShowSchemaDrawer(true)} />
+              <Icon.FiSettings className="w-4 h-auto" />
             </button>
           )}
         </div>

--- a/src/components/ConversationView/index.tsx
+++ b/src/components/ConversationView/index.tsx
@@ -133,6 +133,7 @@ const ConversationView = () => {
     // Construct the system prompt
     const messageList = messageStore.getState().messageList.filter((message: Message) => message.conversationId === currentConversation.id);
     const promptGenerator = getPromptGeneratorOfAssistant(getAssistantById(currentConversation.assistantId)!);
+    let dbPrompt = promptGenerator();
     const maxToken = getModel(settingStore.setting.openAIApiConfig?.model || "").max_token;
     // Squeeze as much prompt as possible under the token limit, the prompt is in the order of:
     // 1. Assistant specific prompt with database schema if applicable.
@@ -144,7 +145,7 @@ const ConversationView = () => {
     // 2. Assistant specific prompt with database schema if applicable.
     // 3. A list of previous exchanges
     let tokens = countTextTokens(userPrompt);
-    let dbPrompt = promptGenerator();
+
     // Augument with database schema if available
     if (connectionStore.currentConnectionCtx?.database) {
       const schemaList = await connectionStore.getOrFetchDatabaseSchema(connectionStore.currentConnectionCtx?.database);

--- a/src/components/SchemaDrawer.tsx
+++ b/src/components/SchemaDrawer.tsx
@@ -73,7 +73,7 @@ const SchemaDrawer = (props: Props) => {
         </button>
         <h3 className="font-bold text-2xl mt-4">Current conversation related schema</h3>
         <div>
-          <CodeBlock language="SQL" value={prompt} messageId={currentConversation?.id || ""} />
+          <CodeBlock language="Prompt" value={prompt} messageId={currentConversation?.id || ""} wrapLongLines={true} />
         </div>
       </div>
     </Drawer>

--- a/src/components/SchemaDrawer.tsx
+++ b/src/components/SchemaDrawer.tsx
@@ -1,16 +1,76 @@
 import { Drawer } from "@mui/material";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import Icon from "./Icon";
+import { getAssistantById, getPromptGeneratorOfAssistant, useConnectionStore, useConversationStore } from "@/store";
+import { countTextTokens, getModel } from "@/utils";
+import toast from "react-hot-toast";
 
 interface Props {
   close: () => void;
 }
 
 const SchemaDrawer = (props: Props) => {
+  const conversationStore = useConversationStore();
+  const connectionStore = useConnectionStore();
+
+  const currentConversation = conversationStore.getConversationById(conversationStore.currentConversationId);
+
   useEffect(() => {
     // TODO: initial state with current conversation.
   }, []);
+  useEffect(async () => {
+    if (!currentConversation) return;
+    const promptGenerator = getPromptGeneratorOfAssistant(getAssistantById(currentConversation.assistantId)!);
+    let dbPrompt = promptGenerator();
+    // const maxToken = getModel(settingStore.setting.openAIApiConfig?.model || "").max_token;
+    const maxToken = 4000;
+    // Squeeze as much prompt as possible under the token limit, the prompt is in the order of:
+    // 1. Assistant specific prompt with database schema if applicable.
+    // 2. A list of previous exchanges.
+    // 3. The current user prompt.
+    //
+    // The priority to fill in the prompt is in the order of:
+    // 1. The current user prompt.
+    // 2. Assistant specific prompt with database schema if applicable.
+    // 3. A list of previous exchanges
+    // let tokens = countTextTokens(userPrompt);
+    let tokens = 0;
 
+    // Augument with database schema if available
+    if (connectionStore.currentConnectionCtx?.database) {
+      let schema = "";
+      try {
+        const schemaList = await connectionStore.getOrFetchDatabaseSchema(connectionStore.currentConnectionCtx?.database);
+        // Empty table name(such as []) denote all table. [] and `undefined` both are false in `if`
+        const tableList: string[] = [];
+        const selectedSchema = schemaList.find((schema: any) => schema.name == (currentConversation.selectedSchemaName || ""));
+        if (currentConversation.selectedTablesName) {
+          currentConversation.selectedTablesName.forEach((tableName: string) => {
+            const table = selectedSchema?.tables.find((table: any) => table.name == tableName);
+            tableList.push(table!.structure);
+          });
+        } else {
+          for (const table of selectedSchema?.tables || []) {
+            tableList.push(table!.structure);
+          }
+        }
+        if (tableList) {
+          for (const table of tableList) {
+            if (tokens < maxToken / 2) {
+              tokens += countTextTokens(table);
+              schema += table;
+            }
+          }
+        }
+      } catch (error: any) {
+        toast.error(error.message);
+      }
+      dbPrompt = promptGenerator(schema);
+      setPrompt(dbPrompt);
+    }
+  }, []);
+
+  const [prompt, setPrompt] = useState<string>("");
   const close = () => props.close();
 
   return (
@@ -20,6 +80,7 @@ const SchemaDrawer = (props: Props) => {
           <Icon.IoMdClose className="w-full h-auto" />
         </button>
         <h3 className="font-bold text-2xl mt-4">Current conversation related schema</h3>
+        <div>{prompt}</div>
       </div>
     </Drawer>
   );

--- a/src/utils/openai.ts
+++ b/src/utils/openai.ts
@@ -20,10 +20,12 @@ export function generateDbPromptFromContext(
   userPrompt?: string
 ): string {
   let schema = "";
-  // userPrompt is message that user want to send to bot. When cat prompt in drawer, userPrompt is undefined.
+  // userPrompt is the message that user want to send to bot. When to look prompt in drawer, userPrompt is undefined.
   let tokens = countTextTokens(userPrompt || "");
 
   // Empty table name(such as []) denote all table. [] and `undefined` both are false in `if`
+  // The above comment is out of date. [] is true in `if` now. And no selected table should not denote all table now.
+  // Because in have Token custom number in connectionSidebar. If [] denote all table. the Token will be inconsistent.
   const tableList: string[] = [];
   const selectedSchema = schemaList.find((schema: Schema) => schema.name == (selectedSchemaName || ""));
   if (selectedTablesName) {


### PR DESCRIPTION
## What does The PR do?
- Move the setting icon position.
- Show the current prompt in `SchemaDrawer`
- Change CodeBlock props, to add a wrapping long text function
- Extract the code of generating db prompt as a function for reuse

## Screenshot
![CleanShot 2023-06-04 at 15 32 54](https://github.com/sqlchat/sqlchat/assets/29306285/46b8eda8-a0e1-468d-a19c-5806921b36fd)


I think the position of the setting icon at the bottom is better than that located on the right of the message. Because it will be consistent when there are some messages and no messages.

## Need to discuss
Before when selectedTablesName is [] or `undefined`. It denotes all tables. But I think it is wrong right now. Because it shows the token in ConnectionSidebar. When no tables be checked, the token is zero. it is inconsistent with the token number of selecting all tables.
Two solutions:
- change token, when no checked table, the token is the value of all tables 
- change `generateDbPromptFromContext`, no checked table denote no table👀