### PR TITLE
add optional config `OPENAI_ORGANIZATION` for users who belong to multiple organizations

### DIFF
--- a/process.d.ts
+++ b/process.d.ts
@@ -13,6 +13,10 @@ declare namespace NodeJS {
     NEXT_PUBLIC_ALLOW_SELF_OPENAI_KEY: string;
     // Required. Do not share your OpenAI API key with anyone! It should remain a secret.
     OPENAI_API_KEY: string;
+    // Optional.For users who belong to multiple organizations,
+    // you can pass a header to specify which organization is used for an API request.
+    // Usage from these API requests will count as usage for the specified organization.
+    OPENAI_ORGANIZATION: string;
     // Optional. OpenAI API endpoint. Defaults to https://api.openai.com.
     OPENAI_API_ENDPOINT: string;
     // Optional. NextAuth.js URL. Defaults to the current domain.

--- a/src/pages/api/chat.ts
+++ b/src/pages/api/chat.ts
@@ -1,6 +1,6 @@
 import { createParser, ParsedEvent, ReconnectInterval } from "eventsource-parser";
 import { NextRequest } from "next/server";
-import { openAIApiEndpoint, openAIApiKey, hasFeature, getModel } from "@/utils";
+import { openAIApiEndpoint, openAIApiKey, openAIOrganization, hasFeature, getModel } from "@/utils";
 
 // Needs Edge for streaming response.
 export const config = {
@@ -93,13 +93,19 @@ const handler = async (req: NextRequest) => {
     }
   }
 
+  let headers: { [key: string]: string } = {
+    "Content-Type": "application/json",
+    Authorization: `Bearer ${apiKey}`,
+  };
+
+  if (openAIOrganization) {
+    headers["OpenAI-Organization"] = openAIOrganization;
+  }
+
   const apiEndpoint = getApiEndpoint(req.headers.get("x-openai-endpoint") || openAIApiEndpoint);
   const model = getModel(req.headers.get("x-openai-model") || "");
   const remoteRes = await fetch(apiEndpoint, {
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${apiKey}`,
-    },
+    headers: headers,
     method: "POST",
     body: JSON.stringify({
       model: model.name,

--- a/src/utils/openai.ts
+++ b/src/utils/openai.ts
@@ -7,6 +7,9 @@ export const openAIApiKey = process.env.OPENAI_API_KEY;
 // openAIApiEndpoint is the API endpoint for OpenAI API. Defaults to https://api.openai.com.
 export const openAIApiEndpoint = process.env.OPENAI_API_ENDPOINT || "https://api.openai.com";
 
+// openAIOrganization a header to specify which organization is used for an API request.
+export const openAIOrganization = process.env.OPENAI_ORGANIZATION;
+
 export const countTextTokens = (text: string) => {
   return encode(text).length;
 };


### PR DESCRIPTION
#143 add optional config for users who belong to multiple organizations pass a header `OpenAI-Organization` to specify which organization is used for an API request

env:
`OPENAI_ORGANIZATION: org-xxx`

Ref: https://platform.openai.com/docs/guides/production-best-practices/setting-up-your-organization
