### PR TITLE
Adding one-click deploy button for RepoCloud.io to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,10 @@ docker run --name sqlchat --platform linux/amd64 --env NEXTAUTH_SECRET="$(openss
    pnpm prisma db seed
    ```
 
+## One-Click Deployment (Self-Hosting)
+
+[![Deploy to RepoCloud](https://d16t0pc4846x52.cloudfront.net/deploylobe.svg)](https://repocloud.io/details/?app_id=293)
+
 ## Star History
 
 [![Star History Chart](https://api.star-history.com/svg?repos=sqlchat/sqlchat&type=Date)](https://star-history.com/#sqlchat/sqlchat&Date)


### PR DESCRIPTION
Adding button enabling community access to deploy template for self-hosting on RepoCloud.io with one click.