### PR TITLE
Add Deepseek Chat support and fix query results display

### DIFF
--- a/src/components/OpenAIApiConfigView.tsx
+++ b/src/components/OpenAIApiConfigView.tsx
@@ -43,6 +43,13 @@ const OpenAIApiConfigView = () => {
       disabled: false,
       tooltip: "",
     },
+    {
+      id: "deepseek-chat",
+      title: `Deepseek Chat`,
+      cost: 1,
+      disabled: false,
+      tooltip: "",
+    },
   ];
 
   const maskedKey = (str: string) => {

--- a/src/utils/execution.ts
+++ b/src/utils/execution.ts
@@ -4,7 +4,8 @@ export const getMessageFromExecutionResult = (result: ExecutionResult): string =
   if (result.error) {
     return result.error;
   }
-  if (result.affectedRows) {
+  // Only return the "rows affected" message if there are no raw results to display
+  if (result.affectedRows && (!result.rawResult || result.rawResult.length === 0)) {
     return `${result.affectedRows} rows affected.`;
   }
   return "";

--- a/src/utils/model.ts
+++ b/src/utils/model.ts
@@ -34,7 +34,16 @@ const gpt4ho = {
   cost_per_call: 10,
 };
 
-export const models = [gpt35turbo, gpt4, gpt4turbo, gpt4ho];
+const deepseekChat = {
+  name: "deepseek-chat",
+  temperature: 0,
+  frequency_penalty: 0.0,
+  presence_penalty: 0.0,
+  max_token: 12000,
+  cost_per_call: 1,
+};
+
+export const models = [gpt35turbo, gpt4, gpt4turbo, gpt4ho, deepseekChat];
 
 export const getModel = (name: string) => {
   for (const model of models) {


### PR DESCRIPTION
## Description
This PR adds two related improvements:

1. Added support for Deepseek Chat as an OpenAI-compatible model option
2. Fixed an issue where query results weren't displayed properly in the UI when using alternative OpenAI-compatible APIs

## Problem
- SQL Chat didn't have Deepseek Chat as a model option
- When using OpenAI-compatible APIs like Deepseek, query results would show "X rows affected" instead of displaying the actual data table

## Solution
1. Added Deepseek Chat model definitions in both the backend model definitions and frontend UI
2. Modified the result display logic to prioritize showing data tables when query results are available, rather than only showing the "rows affected" message

## Testing
Tested with Deepseek Chat API by:
1. Adding the model and connecting with Deepseek API key
2. Running SQL queries and verifying results appear properly in data tables

## Credits
This fix was suggested by GitHub Copilot while troubleshooting the issue. I only fixed a single line to give Deepseek more tokens, as it is just so much cheaper. 