### PR TITLE
chore: openssl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM node:18-alpine AS base
 # Install dependencies only when needed
 FROM base AS deps
 # Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
-RUN apk add --no-cache libc6-compat
+RUN apk add --no-cache libc6-compat openssl1.1-compat
 WORKDIR /app
 
 COPY package.json pnpm-lock.yaml* ./
@@ -22,6 +22,9 @@ FROM base AS runner
 WORKDIR /app
 
 ENV NODE_ENV production
+
+# Install OpenSSL for Prisma in production
+RUN apk add --no-cache openssl1.1-compat
 
 RUN addgroup --system --gid 1001 nodejs
 RUN adduser --system --uid 1001 nextjs


### PR DESCRIPTION
We've added openssl1.1-compat to both the deps and runner stages in your Dockerfile. This installs the OpenSSL 1.1 libraries that Prisma needs when running on Alpine Linux.

  The changes:
  1. Added openssl1.1-compat to the deps stage (Dockerfile:6)
  2. Added openssl1.1-compat to the runner stage (Dockerfile:27)